### PR TITLE
Add age gate overlay and product detail placeholders

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>About - Toys Before Bed™</title>
+  <link rel="stylesheet" href="styles.css"/>
+  <script defer src="script.js"></script>
+</head>
+<body>
+  <div id="age-gate" class="age-gate-overlay">
+    <div class="age-gate-box">
+      <h2>Adults Only (18+)</h2>
+      <p>This site contains sensual wellness products intended for adults. Are you 18 or older?</p>
+      <button onclick="enterSite()">Yes, Enter</button>
+    </div>
+  </div>
+
+  <div id="site-content" style="display: none;">
+    <header>
+      <h1>About Toys Before Bed™</h1>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="about.html">About</a>
+        <a href="join.html">Join Us</a>
+      </nav>
+    </header>
+
+    <main>
+      <p>More details coming soon.</p>
+    </main>
+
+    <footer>
+      <p>&copy; 2025 Toys Before Bed™. All rights reserved.</p>
+      <a href="#">Privacy</a> | <a href="#">Terms</a>
+    </footer>
+  </div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -8,47 +8,67 @@
   <script defer src="script.js"></script>
 </head>
 <body>
-  <div id="age-verification" class="modal">
-    <div class="modal-content">
-      <h2>Adults Only</h2>
-      <p>You must be 18 years or older to enter.</p>
-      <button onclick="verifyAge()">I’m 18+</button>
+  <!-- Splash Screen for Age Verification -->
+  <div id="age-gate" class="age-gate-overlay">
+    <div class="age-gate-box">
+      <h2>Adults Only (18+)</h2>
+      <p>This site contains sensual wellness products intended for adults. Are you 18 or older?</p>
+      <button onclick="enterSite()">Yes, Enter</button>
     </div>
   </div>
 
-  <main style="display:none" id="main-content">
+  <div id="site-content" style="display: none;">
     <header>
       <h1>Toys Before Bed™</h1>
       <p class="tagline">Unwrap pleasure. Every night.</p>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="about.html">About</a>
+        <a href="join.html">Join Us</a>
+      </nav>
     </header>
 
-    <section class="email-signup">
-      <h2>Get Notified at Launch</h2>
-      <form action="#" method="POST">
-        <input type="email" name="email" placeholder="Enter your email" required />
-        <button type="submit">Join the Waitlist</button>
-      </form>
-    </section>
+    <main>
+      <section class="email-signup">
+        <h2>Get Notified at Launch</h2>
+        <form action="#" method="POST">
+          <input type="email" name="email" placeholder="Enter your email" required />
+          <button type="submit">Join the Waitlist</button>
+        </form>
+      </section>
 
-    <section class="recruitment">
-      <h2>Join Our Team</h2>
-      <p>We’re hiring content creators, brand reps, and influencers. <a href="mailto:recruit@toysbeforebed.com">Contact us</a>.</p>
-    </section>
+      <section class="recruitment">
+        <h2>Join Our Team</h2>
+        <p>We’re hiring content creators, brand reps, and influencers. <a href="join.html">Apply Now</a>.</p>
+      </section>
 
-    <section class="product-preview">
-      <h2>Coming Soon</h2>
-      <div class="products">
-        <div class="product-card">Discreet Vibrators</div>
-        <div class="product-card">Couples Kits</div>
-        <div class="product-card">Massage Oils</div>
-        <div class="product-card">Luxury Toys</div>
-      </div>
-    </section>
+      <section class="product-preview">
+        <h2>Coming Soon</h2>
+        <div class="products">
+          <div class="product-card" onclick="location.href='products/toy-a.html'">
+            <h3>Discreet Vibrators</h3>
+            <button class="shop" onclick="event.stopPropagation(); location.href='products/toy-a.html'">Shop Now</button>
+          </div>
+          <div class="product-card" onclick="location.href='products/toy-b.html'">
+            <h3>Couples Kits</h3>
+            <button class="shop" onclick="event.stopPropagation(); location.href='products/toy-b.html'">Shop Now</button>
+          </div>
+          <div class="product-card" onclick="location.href='products/toy-c.html'">
+            <h3>Massage Oils</h3>
+            <button class="shop" onclick="event.stopPropagation(); location.href='products/toy-c.html'">Shop Now</button>
+          </div>
+          <div class="product-card" onclick="location.href='products/toy-d.html'">
+            <h3>Luxury Toys</h3>
+            <button class="shop" onclick="event.stopPropagation(); location.href='products/toy-d.html'">Shop Now</button>
+          </div>
+        </div>
+      </section>
+    </main>
 
     <footer>
       <p>&copy; 2025 Toys Before Bed™. All rights reserved.</p>
       <a href="#">Privacy</a> | <a href="#">Terms</a>
     </footer>
-  </main>
+  </div>
 </body>
 </html>

--- a/join.html
+++ b/join.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Join Us - Toys Before Bed™</title>
+  <link rel="stylesheet" href="styles.css"/>
+  <script defer src="script.js"></script>
+</head>
+<body>
+  <div id="age-gate" class="age-gate-overlay">
+    <div class="age-gate-box">
+      <h2>Adults Only (18+)</h2>
+      <p>This site contains sensual wellness products intended for adults. Are you 18 or older?</p>
+      <button onclick="enterSite()">Yes, Enter</button>
+    </div>
+  </div>
+
+  <div id="site-content" style="display: none;">
+    <header>
+      <h1>Join Us</h1>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="about.html">About</a>
+        <a href="join.html">Join Us</a>
+      </nav>
+    </header>
+
+    <main>
+      <p>Apply to be part of our team. Opportunities coming soon.</p>
+    </main>
+
+    <footer>
+      <p>&copy; 2025 Toys Before Bed™. All rights reserved.</p>
+      <a href="#">Privacy</a> | <a href="#">Terms</a>
+    </footer>
+  </div>
+</body>
+</html>

--- a/products/toy-a.html
+++ b/products/toy-a.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Discreet Vibrators - Toys Before Bed™</title>
+  <link rel="stylesheet" href="../styles.css"/>
+  <script defer src="../script.js"></script>
+</head>
+<body>
+  <div id="age-gate" class="age-gate-overlay">
+    <div class="age-gate-box">
+      <h2>Adults Only (18+)</h2>
+      <p>This site contains sensual wellness products intended for adults. Are you 18 or older?</p>
+      <button onclick="enterSite()">Yes, Enter</button>
+    </div>
+  </div>
+
+  <div id="site-content" style="display: none;">
+    <header>
+      <h1>Discreet Vibrators</h1>
+      <nav>
+        <a href="../index.html">Home</a>
+        <a href="../about.html">About</a>
+        <a href="../join.html">Join Us</a>
+      </nav>
+    </header>
+
+    <main>
+      <p>Product details coming soon.</p>
+    </main>
+
+    <footer>
+      <p>&copy; 2025 Toys Before Bed™. All rights reserved.</p>
+      <a href="#">Privacy</a> | <a href="#">Terms</a>
+    </footer>
+  </div>
+</body>
+</html>

--- a/products/toy-b.html
+++ b/products/toy-b.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Couples Kits - Toys Before Bed™</title>
+  <link rel="stylesheet" href="../styles.css"/>
+  <script defer src="../script.js"></script>
+</head>
+<body>
+  <div id="age-gate" class="age-gate-overlay">
+    <div class="age-gate-box">
+      <h2>Adults Only (18+)</h2>
+      <p>This site contains sensual wellness products intended for adults. Are you 18 or older?</p>
+      <button onclick="enterSite()">Yes, Enter</button>
+    </div>
+  </div>
+
+  <div id="site-content" style="display: none;">
+    <header>
+      <h1>Couples Kits</h1>
+      <nav>
+        <a href="../index.html">Home</a>
+        <a href="../about.html">About</a>
+        <a href="../join.html">Join Us</a>
+      </nav>
+    </header>
+
+    <main>
+      <p>Product details coming soon.</p>
+    </main>
+
+    <footer>
+      <p>&copy; 2025 Toys Before Bed™. All rights reserved.</p>
+      <a href="#">Privacy</a> | <a href="#">Terms</a>
+    </footer>
+  </div>
+</body>
+</html>

--- a/products/toy-c.html
+++ b/products/toy-c.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Massage Oils - Toys Before Bed™</title>
+  <link rel="stylesheet" href="../styles.css"/>
+  <script defer src="../script.js"></script>
+</head>
+<body>
+  <div id="age-gate" class="age-gate-overlay">
+    <div class="age-gate-box">
+      <h2>Adults Only (18+)</h2>
+      <p>This site contains sensual wellness products intended for adults. Are you 18 or older?</p>
+      <button onclick="enterSite()">Yes, Enter</button>
+    </div>
+  </div>
+
+  <div id="site-content" style="display: none;">
+    <header>
+      <h1>Massage Oils</h1>
+      <nav>
+        <a href="../index.html">Home</a>
+        <a href="../about.html">About</a>
+        <a href="../join.html">Join Us</a>
+      </nav>
+    </header>
+
+    <main>
+      <p>Product details coming soon.</p>
+    </main>
+
+    <footer>
+      <p>&copy; 2025 Toys Before Bed™. All rights reserved.</p>
+      <a href="#">Privacy</a> | <a href="#">Terms</a>
+    </footer>
+  </div>
+</body>
+</html>

--- a/products/toy-d.html
+++ b/products/toy-d.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Luxury Toys - Toys Before Bed™</title>
+  <link rel="stylesheet" href="../styles.css"/>
+  <script defer src="../script.js"></script>
+</head>
+<body>
+  <div id="age-gate" class="age-gate-overlay">
+    <div class="age-gate-box">
+      <h2>Adults Only (18+)</h2>
+      <p>This site contains sensual wellness products intended for adults. Are you 18 or older?</p>
+      <button onclick="enterSite()">Yes, Enter</button>
+    </div>
+  </div>
+
+  <div id="site-content" style="display: none;">
+    <header>
+      <h1>Luxury Toys</h1>
+      <nav>
+        <a href="../index.html">Home</a>
+        <a href="../about.html">About</a>
+        <a href="../join.html">Join Us</a>
+      </nav>
+    </header>
+
+    <main>
+      <p>Product details coming soon.</p>
+    </main>
+
+    <footer>
+      <p>&copy; 2025 Toys Before Bed™. All rights reserved.</p>
+      <a href="#">Privacy</a> | <a href="#">Terms</a>
+    </footer>
+  </div>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,12 @@
-function verifyAge() {
-  document.getElementById('age-verification').style.display = 'none';
-  document.getElementById('main-content').style.display = 'block';
+function enterSite() {
+  document.getElementById('age-gate').style.display = 'none';
+  document.getElementById('site-content').style.display = 'block';
+  localStorage.setItem('ageVerified', 'true');
 }
+
+window.addEventListener('DOMContentLoaded', () => {
+  if (localStorage.getItem('ageVerified') === 'true') {
+    document.getElementById('age-gate').style.display = 'none';
+    document.getElementById('site-content').style.display = 'block';
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -6,28 +6,48 @@ body {
   color: #333;
   text-align: center;
 }
+
 header {
   padding: 2rem;
   background-color: #ffe4ec;
 }
+
+nav {
+  margin-top: 1rem;
+}
+
+nav a {
+  margin: 0 0.5rem;
+  color: #c71585;
+  text-decoration: none;
+}
+
+nav a:hover {
+  text-decoration: underline;
+}
+
 h1 {
   color: #c71585;
   margin-bottom: 0.2em;
 }
+
 .tagline {
   font-size: 1.2rem;
   color: #555;
 }
+
 .email-signup, .recruitment, .product-preview {
   margin: 2rem auto;
   max-width: 600px;
 }
+
 input[type="email"] {
   padding: 0.5rem;
   width: 70%;
   border: 1px solid #ccc;
   border-radius: 5px;
 }
+
 button {
   padding: 0.5rem 1rem;
   margin-left: 0.5rem;
@@ -35,31 +55,43 @@ button {
   color: white;
   border: none;
   border-radius: 5px;
+  cursor: pointer;
 }
+
+button.shop {
+  margin-top: 1rem;
+}
+
 footer {
   margin-top: 2rem;
   font-size: 0.9rem;
 }
-.modal {
+
+/* Age gate overlay */
+.age-gate-overlay {
   position: fixed;
-  top: 0; left: 0; width: 100%; height: 100%;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
   background: rgba(0,0,0,0.85);
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 10;
+  z-index: 1000;
 }
-.modal-content {
+
+.age-gate-box {
   background: white;
   padding: 2rem;
   border-radius: 10px;
   text-align: center;
 }
+
 .products {
   display: flex;
   justify-content: space-around;
   flex-wrap: wrap;
 }
+
 .product-card {
   background: #fff;
   border: 1px solid #ccc;
@@ -67,4 +99,5 @@ footer {
   padding: 1rem;
   margin: 1rem;
   width: 150px;
+  cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- Add site-wide age verification overlay with persistence
- Link product cards and buttons to individual placeholder pages
- Introduce navigation to About and Join pages with recruitment CTA update

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b218936c988326be466265101b6b4f