### PR TITLE
Switch HTML meta tags to new domain and verify includes

### DIFF
--- a/bedside/guide-1.html
+++ b/bedside/guide-1.html
@@ -1,4 +1,7 @@
-<!DOCTYPE html><html><head><link href="../styles/styles.css" rel="stylesheet"><title>A Beginner’s Guide to Choosing Your First Vibrator</title>  <link href="../styles/styles.css" rel="stylesheet">
+<!DOCTYPE html><html><head><link href="../styles/styles.css" rel="stylesheet"><title>A Beginner’s Guide to Choosing Your First Vibrator</title>
+  <meta property="og:url" content="https://toysbeforebed.com/bedside/guide-1.html">
+  <meta property="og:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
+  <meta name="twitter:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
 </head><body id="top">
     <div id="navbar"></div><div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>A Beginner’s Guide to Choosing Your First Vibrator</h1><p><em>Published: March 1, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for A Beginner’s Guide to Choosing Your First Vibrator.</p><div class='footer-hero-strip'><p>Discreet Shipping • Inclusive Designs • 100% Comfort Guarantee</p></div>
 <div class='site-footer'><div class='legal'>© 2025 Toys Before Bed™ — Curated for all bodies, every night. Last updated: <span id="last-updated"></span>.</div></div><script>const now=new Date();document.getElementById("last-updated").textContent=now.toLocaleDateString(undefined,{year:'numeric',month:'long'});</script>    <div id="footer"></div>

--- a/bedside/guide-2.html
+++ b/bedside/guide-2.html
@@ -1,4 +1,7 @@
-<!DOCTYPE html><html><head><link href="../styles/styles.css" rel="stylesheet"><title>Understanding Discreet Shipping & Privacy</title>  <link href="../styles/styles.css" rel="stylesheet">
+<!DOCTYPE html><html><head><link href="../styles/styles.css" rel="stylesheet"><title>Understanding Discreet Shipping & Privacy</title>
+  <meta property="og:url" content="https://toysbeforebed.com/bedside/guide-2.html">
+  <meta property="og:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
+  <meta name="twitter:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
 </head><body id="top">
     <div id="navbar"></div><div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>Understanding Discreet Shipping & Privacy</h1><p><em>Published: March 10, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for Understanding Discreet Shipping & Privacy.</p><div class='footer-hero-strip'><p>Discreet Shipping • Inclusive Designs • 100% Comfort Guarantee</p></div>
 <div class='site-footer'><div class='legal'>© 2025 Toys Before Bed™ — Curated for all bodies, every night. Last updated: <span id="last-updated"></span>.</div></div><script>const now=new Date();document.getElementById("last-updated").textContent=now.toLocaleDateString(undefined,{year:'numeric',month:'long'});</script>    <div id="footer"></div>

--- a/bedside/guide-3.html
+++ b/bedside/guide-3.html
@@ -1,4 +1,7 @@
-<!DOCTYPE html><html><head><link href="../styles/styles.css" rel="stylesheet"><title>Couples’ Toys: How to Explore Together</title>  <link href="../styles/styles.css" rel="stylesheet">
+<!DOCTYPE html><html><head><link href="../styles/styles.css" rel="stylesheet"><title>Couples’ Toys: How to Explore Together</title>
+  <meta property="og:url" content="https://toysbeforebed.com/bedside/guide-3.html">
+  <meta property="og:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
+  <meta name="twitter:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
 </head><body id="top">
     <div id="navbar"></div><div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>Couples’ Toys: How to Explore Together</h1><p><em>Published: March 20, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for Couples’ Toys: How to Explore Together.</p><div class='footer-hero-strip'><p>Discreet Shipping • Inclusive Designs • 100% Comfort Guarantee</p></div>
 <div class='site-footer'><div class='legal'>© 2025 Toys Before Bed™ — Curated for all bodies, every night. Last updated: <span id="last-updated"></span>.</div></div><script>const now=new Date();document.getElementById("last-updated").textContent=now.toLocaleDateString(undefined,{year:'numeric',month:'long'});</script>    <div id="footer"></div>

--- a/sitemap.html
+++ b/sitemap.html
@@ -1,4 +1,7 @@
-<!DOCTYPE html><html><head><link href="styles/styles.css" rel="stylesheet"><title>Sitemap</title>  <link href="styles/styles.css" rel="stylesheet">
+<!DOCTYPE html><html><head><link href="styles/styles.css" rel="stylesheet"><title>Sitemap</title>
+  <meta property="og:url" content="https://toysbeforebed.com/sitemap.html">
+  <meta property="og:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
+  <meta name="twitter:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
 </head><body id="top">
     <div id="navbar"></div><h1>Sitemap</h1><ul><li><a href='index.html'>index.html</a></li><li><a href='about.html'>about.html</a></li><li><a href='join.html'>join.html</a></li><li><a href='faq.html'>faq.html</a></li><li><a href='contact.html'>contact.html</a></li><li><a href='privacy.html'>privacy.html</a></li><li><a href='privacy-uk.html'>privacy-uk.html</a></li><li><a href='terms.html'>terms.html</a></li><li><a href='returns.html'>returns.html</a></li><li><a href='2257.html'>2257.html</a></li><li><a href='bedside.html'>bedside.html</a></li><li><a href='products/toy-a.html'>products/toy-a.html</a></li><li><a href='products/toy-b.html'>products/toy-b.html</a></li><li><a href='products/toy-c.html'>products/toy-c.html</a></li><li><a href='bedside/guide-1.html'>bedside/guide-1.html</a></li><li><a href='bedside/guide-2.html'>bedside/guide-2.html</a></li><li><a href='bedside/guide-3.html'>bedside/guide-3.html</a></li></ul><div class='footer-hero-strip'><p>Discreet Shipping • Inclusive Designs • 100% Comfort Guarantee</p></div>
     <div id="footer"></div>


### PR DESCRIPTION
## Summary
- Add Open Graph/Twitter meta tags with the `toysbeforebed.com` domain on bedside guides and sitemap
- Remove duplicate stylesheet links from nested pages

## Testing
- `python3 check_html.py`

------
https://chatgpt.com/codex/tasks/task_e_68b6390f8c088326aa61cc463a0b898d