### PR TITLE
chore: add HTML include verifier and CI

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,4 +1,4 @@
-name: Verify and Fix HTML Includes
+name: Verify and Fix HTML
 
 on:
   push:
@@ -18,22 +18,23 @@ jobs:
         with:
           node-version: 18
 
-      - name: Run verifier (with auto-fix)
+      - name: Run verifier
         run: node scripts/verify-includes.js
 
-      - name: Upload verify report
+      - name: Upload reports
         uses: actions/upload-artifact@v4
         with:
-          name: verify-report
-          path: verify-report.txt
+          name: verify-reports
+          path: |
+            verify-report.txt
+            broken-links.txt
 
       - name: Commit fixes (if any)
-        if: success()
         run: |
           if [ -n "$(git status --porcelain)" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add .
-            git commit -m "chore: auto-fix navbar/footer includes"
+            git commit -m "chore: auto-fix includes + link validation"
             git push
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 .vscode/
 .idea/
 verify-report.txt
+broken-links.txt


### PR DESCRIPTION
## Summary
- add `verify-includes.js` script to ensure navbar/footer includes and check local links
- run verifier in GitHub Actions, upload reports, and auto-commit fixes
- ignore verification artifacts

## Testing
- `node scripts/verify-includes.js`


------
https://chatgpt.com/codex/tasks/task_e_68b641c521cc8326a5a787fec44f20e1