### PR TITLE
Automate sitemap generation for footer links

### DIFF
--- a/.github/workflows/update-sitemap.yml
+++ b/.github/workflows/update-sitemap.yml
@@ -1,0 +1,27 @@
+name: Update Sitemap
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  update-sitemap:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Generate sitemap
+        run: node scripts/sitemap-generator.js
+      - name: Commit and push changes
+        run: |
+          if [ -n "$(git status --porcelain sitemap.html sitemap.xml)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add sitemap.html sitemap.xml
+            git commit -m "chore: auto-update sitemap"
+            git push
+          fi

--- a/scripts/sitemap-generator.js
+++ b/scripts/sitemap-generator.js
@@ -6,7 +6,7 @@ const footerPath = path.join(rootDir, 'includes', 'footer.html');
 const footerHtml = fs.readFileSync(footerPath, 'utf-8');
 
 // Extract links that start with '/'
-const linkRegex = /<a\s+href="([^"]+)">([^<]+)<\/a>/g;
+const linkRegex = /<a\s+href="([^"]+)"[^>]*>([^<]+)<\/a>/g;
 const links = [];
 let match;
 while ((match = linkRegex.exec(footerHtml))) {
@@ -41,20 +41,13 @@ ${links.map(l => `      <li><a href="${l.href}">${l.text}</a></li>`).join('\n')}
 `;
 fs.writeFileSync(path.join(rootDir, 'sitemap.html'), sitemapHtml, 'utf-8');
 
-// Generate sitemap.xml
+// Generate sitemap.xml with today's date for all pages
 const BASE_URL = 'https://toysbeforebed.com';
+const today = new Date().toISOString().split('T')[0];
 let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';
 xml += '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n';
 links.forEach(link => {
-  const filePath = path.join(rootDir, link.href.replace(/^\//, ''));
-  let lastmod;
-  try {
-    const stat = fs.statSync(filePath);
-    lastmod = stat.mtime.toISOString().split('T')[0];
-  } catch (e) {
-    lastmod = new Date().toISOString().split('T')[0];
-  }
-  xml += `  <url>\n    <loc>${BASE_URL}${link.href}</loc>\n    <lastmod>${lastmod}</lastmod>\n  </url>\n`;
+  xml += `  <url>\n    <loc>${BASE_URL}${link.href}</loc>\n    <lastmod>${today}</lastmod>\n  </url>\n`;
 });
 xml += '</urlset>\n';
 fs.writeFileSync(path.join(rootDir, 'sitemap.xml'), xml, 'utf-8');

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -14,31 +14,31 @@
   </url>
   <url>
     <loc>https://toysbeforebed.com/faq.html</loc>
-    <lastmod>2025-09-01</lastmod>
+    <lastmod>2025-09-02</lastmod>
   </url>
   <url>
     <loc>https://toysbeforebed.com/contact.html</loc>
-    <lastmod>2025-09-01</lastmod>
+    <lastmod>2025-09-02</lastmod>
   </url>
   <url>
     <loc>https://toysbeforebed.com/privacy.html</loc>
-    <lastmod>2025-09-01</lastmod>
+    <lastmod>2025-09-02</lastmod>
   </url>
   <url>
     <loc>https://toysbeforebed.com/privacy-uk.html</loc>
-    <lastmod>2025-09-01</lastmod>
+    <lastmod>2025-09-02</lastmod>
   </url>
   <url>
     <loc>https://toysbeforebed.com/terms.html</loc>
-    <lastmod>2025-09-01</lastmod>
+    <lastmod>2025-09-02</lastmod>
   </url>
   <url>
     <loc>https://toysbeforebed.com/returns.html</loc>
-    <lastmod>2025-09-01</lastmod>
+    <lastmod>2025-09-02</lastmod>
   </url>
   <url>
     <loc>https://toysbeforebed.com/2257.html</loc>
-    <lastmod>2025-09-01</lastmod>
+    <lastmod>2025-09-02</lastmod>
   </url>
   <url>
     <loc>https://toysbeforebed.com/sitemap.html</loc>


### PR DESCRIPTION
## Summary
- add workflow to rebuild and commit sitemap on pushes to main
- generate sitemap.xml with today's date using links from footer
- ensure sitemap pages mirror footer structure

## Testing
- `node scripts/sitemap-generator.js`
- `rg '<div id="footer"></div>' -l | sort`
- `node - <<'NODE' ...` (checked footer links exist)
- `apt-get update` *(failed: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6480132948326a47468867f0d2df3