### PR TITLE
feat: add automated sitemap generation

### DIFF
--- a/.github/workflows/update-sitemap.yml
+++ b/.github/workflows/update-sitemap.yml
@@ -1,0 +1,25 @@
+name: Update sitemap
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Generate sitemap
+        run: node scripts/sitemap-generator.js
+      - name: Commit changes
+        run: |
+          if [[ `git status --porcelain sitemap.html sitemap.xml` ]]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add sitemap.html sitemap.xml
+            git commit -m "chore: auto-update sitemap"
+            git push
+          fi

--- a/scripts/sitemap-generator.js
+++ b/scripts/sitemap-generator.js
@@ -2,59 +2,72 @@ const fs = require('fs');
 const path = require('path');
 
 const rootDir = path.resolve(__dirname, '..');
-const footerPath = path.join(rootDir, 'includes', 'footer.html');
-const footerHtml = fs.readFileSync(footerPath, 'utf-8');
+const today = new Date().toISOString().split('T')[0];
 
-// Extract links that start with '/'
+// Read footer links
+const footerHtml = fs.readFileSync(path.join(rootDir, 'includes', 'footer.html'), 'utf-8');
+const footerLinks = [];
 const linkRegex = /<a\s+href="([^"]+)">([^<]+)<\/a>/g;
-const links = [];
 let match;
-while ((match = linkRegex.exec(footerHtml))) {
-  const href = match[1];
-  const text = match[2];
-  if (href.startsWith('/')) {
-    links.push({ href, text });
+while ((match = linkRegex.exec(footerHtml)) !== null) {
+  footerLinks.push({ href: match[1], text: match[2] });
+}
+
+const coreNames = ['Home', 'About', 'Join Us', 'FAQ', 'Contact'];
+const policyNames = ['Privacy (US)', 'Privacy (UK)', 'Terms', 'Returns', '2257 Compliance'];
+const core = [];
+const policies = [];
+footerLinks.forEach(link => {
+  if (coreNames.includes(link.text)) {
+    core.push(link);
+  } else if (policyNames.includes(link.text)) {
+    policies.push(link);
   }
+});
+
+function titleize(str) {
+  return str.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+}
+
+// Guides
+const guides = [{ href: '/bedside.html', text: 'Bedside Reading' }];
+const guidesDir = path.join(rootDir, 'bedside');
+if (fs.existsSync(guidesDir)) {
+  fs.readdirSync(guidesDir).filter(f => f.endsWith('.html')).forEach(f => {
+    guides.push({ href: `/bedside/${f}`, text: titleize(f.replace('.html', '')) });
+  });
+}
+
+// Blog
+const blog = [{ href: '/blog.html', text: 'Blog Index' }];
+const blogDir = path.join(rootDir, 'blog');
+if (fs.existsSync(blogDir)) {
+  fs.readdirSync(blogDir).filter(f => f.endsWith('.html')).forEach(f => {
+    blog.push({ href: `/blog/${f}`, text: titleize(f.replace('.html', '')) });
+  });
+}
+
+const groups = [
+  { title: 'Core Pages', links: core },
+  { title: 'Policies', links: policies },
+  { title: 'Guides', links: guides },
+  { title: 'Blog', links: blog }
+];
+
+function renderSection(group) {
+  return `    <section>\n      <h2>${group.title}</h2>\n      <ul>\n${group.links.map(l => `        <li><a href="${l.href}">${l.text}</a></li>`).join('\n')}\n      </ul>\n    </section>`;
 }
 
 // Generate sitemap.html
-const sitemapHtml = `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Sitemap | Toys Before Bed™</title>
-  <link href="styles/styles.css" rel="stylesheet">
-</head>
-<body id="top">
-  <div id="navbar"></div>
-  <main class="container">
-    <h1>Sitemap</h1>
-    <ul>
-${links.map(l => `      <li><a href="${l.href}">${l.text}</a></li>`).join('\n')}
-    </ul>
-  </main>
-  <div id="footer"></div>
-  <script src="scripts/include.js" defer></script>
-</body>
-</html>
-`;
+const sitemapHtml = `<!DOCTYPE html>\n<html lang="en">\n<head>\n  <meta charset="UTF-8">\n  <meta name="viewport" content="width=device-width, initial-scale=1.0">\n  <title>Sitemap | Toys Before Bed™</title>\n  <link href="styles/styles.css" rel="stylesheet">\n  <style>\n    section {margin-bottom: 2rem;}\n    ul {list-style: none; padding-left: 0;}\n    li {margin-bottom: .5rem;}\n    a:hover {text-decoration: underline;}\n  </style>\n</head>\n<body id="top">\n  <div id="navbar"></div>\n  <main class="container">\n    <h1>Sitemap</h1>\n${groups.map(renderSection).join('\n')}\n  </main>\n  <div id="footer"></div>\n  <script src="scripts/include.js" defer></script>\n</body>\n</html>\n`;
 fs.writeFileSync(path.join(rootDir, 'sitemap.html'), sitemapHtml, 'utf-8');
 
 // Generate sitemap.xml
-const BASE_URL = 'https://toysbeforebed.com';
+const allLinks = groups.flatMap(g => g.links);
 let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';
 xml += '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n';
-links.forEach(link => {
-  const filePath = path.join(rootDir, link.href.replace(/^\//, ''));
-  let lastmod;
-  try {
-    const stat = fs.statSync(filePath);
-    lastmod = stat.mtime.toISOString().split('T')[0];
-  } catch (e) {
-    lastmod = new Date().toISOString().split('T')[0];
-  }
-  xml += `  <url>\n    <loc>${BASE_URL}${link.href}</loc>\n    <lastmod>${lastmod}</lastmod>\n  </url>\n`;
+allLinks.forEach(link => {
+  xml += `  <url>\n    <loc>https://toysbeforebed.com${link.href}</loc>\n    <lastmod>${today}</lastmod>\n  </url>\n`;
 });
 xml += '</urlset>\n';
 fs.writeFileSync(path.join(rootDir, 'sitemap.xml'), xml, 'utf-8');

--- a/sitemap.html
+++ b/sitemap.html
@@ -5,24 +5,55 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Sitemap | Toys Before Bed™</title>
   <link href="styles/styles.css" rel="stylesheet">
+  <style>
+    section {margin-bottom: 2rem;}
+    ul {list-style: none; padding-left: 0;}
+    li {margin-bottom: .5rem;}
+    a:hover {text-decoration: underline;}
+  </style>
 </head>
 <body id="top">
   <div id="navbar"></div>
   <main class="container">
     <h1>Sitemap</h1>
-    <ul>
-      <li><a href="/index.html">Home</a></li>
-      <li><a href="/about.html">About</a></li>
-      <li><a href="/join.html">Join Us</a></li>
-      <li><a href="/faq.html">FAQ</a></li>
-      <li><a href="/contact.html">Contact</a></li>
-      <li><a href="/privacy.html">Privacy (US)</a></li>
-      <li><a href="/privacy-uk.html">Privacy (UK)</a></li>
-      <li><a href="/terms.html">Terms</a></li>
-      <li><a href="/returns.html">Returns</a></li>
-      <li><a href="/2257.html">2257 Compliance</a></li>
-      <li><a href="/sitemap.html">Sitemap</a></li>
-    </ul>
+    <section>
+      <h2>Core Pages</h2>
+      <ul>
+        <li><a href="/index.html">Home</a></li>
+        <li><a href="/about.html">About</a></li>
+        <li><a href="/join.html">Join Us</a></li>
+        <li><a href="/faq.html">FAQ</a></li>
+        <li><a href="/contact.html">Contact</a></li>
+      </ul>
+    </section>
+    <section>
+      <h2>Policies</h2>
+      <ul>
+        <li><a href="/privacy.html">Privacy (US)</a></li>
+        <li><a href="/privacy-uk.html">Privacy (UK)</a></li>
+        <li><a href="/terms.html">Terms</a></li>
+        <li><a href="/returns.html">Returns</a></li>
+        <li><a href="/2257.html">2257 Compliance</a></li>
+      </ul>
+    </section>
+    <section>
+      <h2>Guides</h2>
+      <ul>
+        <li><a href="/bedside.html">Bedside Reading</a></li>
+        <li><a href="/bedside/guide-1.html">Guide 1</a></li>
+        <li><a href="/bedside/guide-2.html">Guide 2</a></li>
+        <li><a href="/bedside/guide-3.html">Guide 3</a></li>
+      </ul>
+    </section>
+    <section>
+      <h2>Blog</h2>
+      <ul>
+        <li><a href="/blog.html">Blog Index</a></li>
+        <li><a href="/blog/post-1.html">Post 1</a></li>
+        <li><a href="/blog/post-2.html">Post 2</a></li>
+        <li><a href="/blog/post-3.html">Post 3</a></li>
+      </ul>
+    </section>
   </main>
   <div id="footer"></div>
   <script src="scripts/include.js" defer></script>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -14,34 +14,62 @@
   </url>
   <url>
     <loc>https://toysbeforebed.com/faq.html</loc>
-    <lastmod>2025-09-01</lastmod>
+    <lastmod>2025-09-02</lastmod>
   </url>
   <url>
     <loc>https://toysbeforebed.com/contact.html</loc>
-    <lastmod>2025-09-01</lastmod>
+    <lastmod>2025-09-02</lastmod>
   </url>
   <url>
     <loc>https://toysbeforebed.com/privacy.html</loc>
-    <lastmod>2025-09-01</lastmod>
+    <lastmod>2025-09-02</lastmod>
   </url>
   <url>
     <loc>https://toysbeforebed.com/privacy-uk.html</loc>
-    <lastmod>2025-09-01</lastmod>
+    <lastmod>2025-09-02</lastmod>
   </url>
   <url>
     <loc>https://toysbeforebed.com/terms.html</loc>
-    <lastmod>2025-09-01</lastmod>
+    <lastmod>2025-09-02</lastmod>
   </url>
   <url>
     <loc>https://toysbeforebed.com/returns.html</loc>
-    <lastmod>2025-09-01</lastmod>
+    <lastmod>2025-09-02</lastmod>
   </url>
   <url>
     <loc>https://toysbeforebed.com/2257.html</loc>
-    <lastmod>2025-09-01</lastmod>
+    <lastmod>2025-09-02</lastmod>
   </url>
   <url>
-    <loc>https://toysbeforebed.com/sitemap.html</loc>
+    <loc>https://toysbeforebed.com/bedside.html</loc>
+    <lastmod>2025-09-02</lastmod>
+  </url>
+  <url>
+    <loc>https://toysbeforebed.com/bedside/guide-1.html</loc>
+    <lastmod>2025-09-02</lastmod>
+  </url>
+  <url>
+    <loc>https://toysbeforebed.com/bedside/guide-2.html</loc>
+    <lastmod>2025-09-02</lastmod>
+  </url>
+  <url>
+    <loc>https://toysbeforebed.com/bedside/guide-3.html</loc>
+    <lastmod>2025-09-02</lastmod>
+  </url>
+  <url>
+    <loc>https://toysbeforebed.com/blog.html</loc>
+    <lastmod>2025-09-02</lastmod>
+  </url>
+  <url>
+    <loc>https://toysbeforebed.com/blog/post-1.html</loc>
+    <lastmod>2025-09-02</lastmod>
+  </url>
+  <url>
+    <loc>https://toysbeforebed.com/blog/post-2.html</loc>
+    <lastmod>2025-09-02</lastmod>
+  </url>
+  <url>
+    <loc>https://toysbeforebed.com/blog/post-3.html</loc>
     <lastmod>2025-09-02</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- build sitemap generator that groups site links for humans and search engines
- add sitemap.html and sitemap.xml with automatic updates
- introduce workflow to regenerate sitemaps on push

## Testing
- `node scripts/sitemap-generator.js`
- `xmllint --noout --schema https://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd sitemap.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b64963f73483268ddca3f417ec6086