### PR TITLE
chore: resolve sitemap generation conflicts

### DIFF
--- a/.github/workflows/update-sitemap.yml
+++ b/.github/workflows/update-sitemap.yml
@@ -2,26 +2,20 @@ name: Update Sitemap
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [main]
 
 jobs:
   update-sitemap:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - name: Generate sitemap
-        run: node scripts/sitemap-generator.js
-      - name: Commit and push changes
-        run: |
-          if [ -n "$(git status --porcelain sitemap.html sitemap.xml)" ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add sitemap.html sitemap.xml
-            git commit -m "chore: auto-update sitemap"
-            git push
-          fi
+      - run: node scripts/sitemap-generator.js
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "chore: auto-update sitemap"
+          file_pattern: sitemap.html sitemap.xml
+          commit_user_name: github-actions[bot]
+          commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/scripts/sitemap-generator.js
+++ b/scripts/sitemap-generator.js
@@ -2,22 +2,35 @@ const fs = require('fs');
 const path = require('path');
 
 const rootDir = path.resolve(__dirname, '..');
-const footerPath = path.join(rootDir, 'includes', 'footer.html');
-const footerHtml = fs.readFileSync(footerPath, 'utf-8');
+const BASE_URL = 'https://toysbeforebed.com';
 
-// Extract links that start with '/'
-const linkRegex = /<a\s+href="([^"]+)"[^>]*>([^<]+)<\/a>/g;
-const links = [];
-let match;
-while ((match = linkRegex.exec(footerHtml))) {
-  const href = match[1];
-  const text = match[2];
-  if (href.startsWith('/')) {
-    links.push({ href, text });
+function getHtmlFiles(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  let files = [];
+  for (const entry of entries) {
+    const res = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (['node_modules', '.git', 'includes', 'scripts'].includes(entry.name)) {
+        continue;
+      }
+      files = files.concat(getHtmlFiles(res));
+    } else if (entry.isFile() && entry.name.endsWith('.html')) {
+      files.push(path.relative(rootDir, res));
+    }
   }
+  return files;
 }
 
-// Generate sitemap.html
+const htmlFiles = getHtmlFiles(rootDir).sort();
+
+const listItems = htmlFiles
+  .map(file => {
+    const urlPath = '/' + file.replace(/\\/g, '/');
+    const url = BASE_URL + urlPath;
+    return `      <li><a href="${url}">${url}</a></li>`;
+  })
+  .join('\n');
+
 const sitemapHtml = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -31,7 +44,7 @@ const sitemapHtml = `<!DOCTYPE html>
   <main class="container">
     <h1>Sitemap</h1>
     <ul>
-${links.map(l => `      <li><a href="${l.href}">${l.text}</a></li>`).join('\n')}
+${listItems}
     </ul>
   </main>
   <div id="footer"></div>
@@ -39,15 +52,16 @@ ${links.map(l => `      <li><a href="${l.href}">${l.text}</a></li>`).join('\n')}
 </body>
 </html>
 `;
+
 fs.writeFileSync(path.join(rootDir, 'sitemap.html'), sitemapHtml, 'utf-8');
 
-// Generate sitemap.xml with today's date for all pages
-const BASE_URL = 'https://toysbeforebed.com';
 const today = new Date().toISOString().split('T')[0];
 let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';
 xml += '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n';
-links.forEach(link => {
-  xml += `  <url>\n    <loc>${BASE_URL}${link.href}</loc>\n    <lastmod>${today}</lastmod>\n  </url>\n`;
+htmlFiles.forEach(file => {
+  const urlPath = '/' + file.replace(/\\/g, '/');
+  const url = BASE_URL + urlPath;
+  xml += `  <url>\n    <loc>${url}</loc>\n    <lastmod>${today}</lastmod>\n  </url>\n`;
 });
 xml += '</urlset>\n';
 fs.writeFileSync(path.join(rootDir, 'sitemap.xml'), xml, 'utf-8');

--- a/sitemap.html
+++ b/sitemap.html
@@ -11,17 +11,32 @@
   <main class="container">
     <h1>Sitemap</h1>
     <ul>
-      <li><a href="/index.html">Home</a></li>
-      <li><a href="/about.html">About</a></li>
-      <li><a href="/join.html">Join Us</a></li>
-      <li><a href="/faq.html">FAQ</a></li>
-      <li><a href="/contact.html">Contact</a></li>
-      <li><a href="/privacy.html">Privacy (US)</a></li>
-      <li><a href="/privacy-uk.html">Privacy (UK)</a></li>
-      <li><a href="/terms.html">Terms</a></li>
-      <li><a href="/returns.html">Returns</a></li>
-      <li><a href="/2257.html">2257 Compliance</a></li>
-      <li><a href="/sitemap.html">Sitemap</a></li>
+      <li><a href="https://toysbeforebed.com/2257.html">https://toysbeforebed.com/2257.html</a></li>
+      <li><a href="https://toysbeforebed.com/about.html">https://toysbeforebed.com/about.html</a></li>
+      <li><a href="https://toysbeforebed.com/bedside.html">https://toysbeforebed.com/bedside.html</a></li>
+      <li><a href="https://toysbeforebed.com/bedside/guide-1.html">https://toysbeforebed.com/bedside/guide-1.html</a></li>
+      <li><a href="https://toysbeforebed.com/bedside/guide-2.html">https://toysbeforebed.com/bedside/guide-2.html</a></li>
+      <li><a href="https://toysbeforebed.com/bedside/guide-3.html">https://toysbeforebed.com/bedside/guide-3.html</a></li>
+      <li><a href="https://toysbeforebed.com/blog.html">https://toysbeforebed.com/blog.html</a></li>
+      <li><a href="https://toysbeforebed.com/blog/post-1.html">https://toysbeforebed.com/blog/post-1.html</a></li>
+      <li><a href="https://toysbeforebed.com/blog/post-2.html">https://toysbeforebed.com/blog/post-2.html</a></li>
+      <li><a href="https://toysbeforebed.com/blog/post-3.html">https://toysbeforebed.com/blog/post-3.html</a></li>
+      <li><a href="https://toysbeforebed.com/contact.html">https://toysbeforebed.com/contact.html</a></li>
+      <li><a href="https://toysbeforebed.com/faq.html">https://toysbeforebed.com/faq.html</a></li>
+      <li><a href="https://toysbeforebed.com/index.html">https://toysbeforebed.com/index.html</a></li>
+      <li><a href="https://toysbeforebed.com/join.html">https://toysbeforebed.com/join.html</a></li>
+      <li><a href="https://toysbeforebed.com/privacy-uk.html">https://toysbeforebed.com/privacy-uk.html</a></li>
+      <li><a href="https://toysbeforebed.com/privacy.html">https://toysbeforebed.com/privacy.html</a></li>
+      <li><a href="https://toysbeforebed.com/products/toy-a.html">https://toysbeforebed.com/products/toy-a.html</a></li>
+      <li><a href="https://toysbeforebed.com/products/toy-b.html">https://toysbeforebed.com/products/toy-b.html</a></li>
+      <li><a href="https://toysbeforebed.com/products/toy-c.html">https://toysbeforebed.com/products/toy-c.html</a></li>
+      <li><a href="https://toysbeforebed.com/products/toy-d.html">https://toysbeforebed.com/products/toy-d.html</a></li>
+      <li><a href="https://toysbeforebed.com/products/toy-e.html">https://toysbeforebed.com/products/toy-e.html</a></li>
+      <li><a href="https://toysbeforebed.com/products/toy-f.html">https://toysbeforebed.com/products/toy-f.html</a></li>
+      <li><a href="https://toysbeforebed.com/returns.html">https://toysbeforebed.com/returns.html</a></li>
+      <li><a href="https://toysbeforebed.com/sitemap.html">https://toysbeforebed.com/sitemap.html</a></li>
+      <li><a href="https://toysbeforebed.com/terms.html">https://toysbeforebed.com/terms.html</a></li>
+      <li><a href="https://toysbeforebed.com/thank-you.html">https://toysbeforebed.com/thank-you.html</a></li>
     </ul>
   </main>
   <div id="footer"></div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://toysbeforebed.com/index.html</loc>
+    <loc>https://toysbeforebed.com/2257.html</loc>
     <lastmod>2025-09-02</lastmod>
   </url>
   <url>
@@ -9,11 +9,35 @@
     <lastmod>2025-09-02</lastmod>
   </url>
   <url>
-    <loc>https://toysbeforebed.com/join.html</loc>
+    <loc>https://toysbeforebed.com/bedside.html</loc>
     <lastmod>2025-09-02</lastmod>
   </url>
   <url>
-    <loc>https://toysbeforebed.com/faq.html</loc>
+    <loc>https://toysbeforebed.com/bedside/guide-1.html</loc>
+    <lastmod>2025-09-02</lastmod>
+  </url>
+  <url>
+    <loc>https://toysbeforebed.com/bedside/guide-2.html</loc>
+    <lastmod>2025-09-02</lastmod>
+  </url>
+  <url>
+    <loc>https://toysbeforebed.com/bedside/guide-3.html</loc>
+    <lastmod>2025-09-02</lastmod>
+  </url>
+  <url>
+    <loc>https://toysbeforebed.com/blog.html</loc>
+    <lastmod>2025-09-02</lastmod>
+  </url>
+  <url>
+    <loc>https://toysbeforebed.com/blog/post-1.html</loc>
+    <lastmod>2025-09-02</lastmod>
+  </url>
+  <url>
+    <loc>https://toysbeforebed.com/blog/post-2.html</loc>
+    <lastmod>2025-09-02</lastmod>
+  </url>
+  <url>
+    <loc>https://toysbeforebed.com/blog/post-3.html</loc>
     <lastmod>2025-09-02</lastmod>
   </url>
   <url>
@@ -21,7 +45,15 @@
     <lastmod>2025-09-02</lastmod>
   </url>
   <url>
-    <loc>https://toysbeforebed.com/privacy.html</loc>
+    <loc>https://toysbeforebed.com/faq.html</loc>
+    <lastmod>2025-09-02</lastmod>
+  </url>
+  <url>
+    <loc>https://toysbeforebed.com/index.html</loc>
+    <lastmod>2025-09-02</lastmod>
+  </url>
+  <url>
+    <loc>https://toysbeforebed.com/join.html</loc>
     <lastmod>2025-09-02</lastmod>
   </url>
   <url>
@@ -29,7 +61,31 @@
     <lastmod>2025-09-02</lastmod>
   </url>
   <url>
-    <loc>https://toysbeforebed.com/terms.html</loc>
+    <loc>https://toysbeforebed.com/privacy.html</loc>
+    <lastmod>2025-09-02</lastmod>
+  </url>
+  <url>
+    <loc>https://toysbeforebed.com/products/toy-a.html</loc>
+    <lastmod>2025-09-02</lastmod>
+  </url>
+  <url>
+    <loc>https://toysbeforebed.com/products/toy-b.html</loc>
+    <lastmod>2025-09-02</lastmod>
+  </url>
+  <url>
+    <loc>https://toysbeforebed.com/products/toy-c.html</loc>
+    <lastmod>2025-09-02</lastmod>
+  </url>
+  <url>
+    <loc>https://toysbeforebed.com/products/toy-d.html</loc>
+    <lastmod>2025-09-02</lastmod>
+  </url>
+  <url>
+    <loc>https://toysbeforebed.com/products/toy-e.html</loc>
+    <lastmod>2025-09-02</lastmod>
+  </url>
+  <url>
+    <loc>https://toysbeforebed.com/products/toy-f.html</loc>
     <lastmod>2025-09-02</lastmod>
   </url>
   <url>
@@ -37,11 +93,15 @@
     <lastmod>2025-09-02</lastmod>
   </url>
   <url>
-    <loc>https://toysbeforebed.com/2257.html</loc>
+    <loc>https://toysbeforebed.com/sitemap.html</loc>
     <lastmod>2025-09-02</lastmod>
   </url>
   <url>
-    <loc>https://toysbeforebed.com/sitemap.html</loc>
+    <loc>https://toysbeforebed.com/terms.html</loc>
+    <lastmod>2025-09-02</lastmod>
+  </url>
+  <url>
+    <loc>https://toysbeforebed.com/thank-you.html</loc>
     <lastmod>2025-09-02</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- update sitemap workflow to run on main and auto-commit sitemap updates
- rewrite sitemap generator to scan all HTML pages and output domain-qualified links
- regenerate sitemap.html and sitemap.xml with links to every page

## Testing
- `node scripts/sitemap-generator.js`
- `node scripts/verify-includes.js` *(fails: Broken link → post-1.html; Broken link → post-2.html; Broken link → post-3.html; Broken link → post-1.html; Broken link → post-3.html; Broken link → post-2.html; Broken link → post-1.html; Broken link → post-2.html; Broken link → /index.html; Broken link → /about.html; Broken link → /join.html; Broken link → /faq.html; Broken link → /contact.html; Broken link → /privacy.html; Broken link → /privacy-uk.html; Broken link → /terms.html; Broken link → /returns.html; Broken link → /2257.html; Broken link → /sitemap.html; Broken link → index.html; Broken link → about.html; Broken link → join.html; Broken link → faq.html; Broken link → contact.html; Broken link → privacy.html; Broken link → terms.html; Broken link → ../index.html; Broken link → ../index.html; Broken link → ../index.html; Broken link → ../index.html; Broken link → ../index.html; Broken link → ../index.html`)


------
https://chatgpt.com/codex/tasks/task_e_68b64bc19a3c83269ba587007ba9ddaf