### PR TITLE
Add dynamic breadcrumbs and clean up footer links

### DIFF
--- a/2257.html
+++ b/2257.html
@@ -9,7 +9,7 @@
 <main class="page"><div class="container">
 <h2>18 U.S.C. §2257 Compliance Notice</h2><p>All models appearing on this website were 18+ at the time of photography. Records required by 18 U.S.C. §2257 are maintained by the custodian of records.</p></div></main>
 
-<div class='footer-hero-strip'><p>Discreet Shipping • Inclusive Designs • 100% Comfort Guarantee</p></div>
+
     <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
   </body></html>

--- a/bedside/guide-1.html
+++ b/bedside/guide-1.html
@@ -3,7 +3,7 @@
   <meta property="og:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
   <meta name="twitter:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
 </head><body id="top">
-    <div id="navbar"></div><div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>A Beginner’s Guide to Choosing Your First Vibrator</h1><p><em>Published: March 1, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for A Beginner’s Guide to Choosing Your First Vibrator.</p><div class='footer-hero-strip'><p>Discreet Shipping • Inclusive Designs • 100% Comfort Guarantee</p></div>
-<div class='site-footer'><div class='legal'>© 2025 Toys Before Bed™ — Curated for all bodies, every night. Last updated: <span id="last-updated"></span>.</div></div><script>const now=new Date();document.getElementById("last-updated").textContent=now.toLocaleDateString(undefined,{year:'numeric',month:'long'});</script>    <div id="footer"></div>
+    <div id="navbar"></div><div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>A Beginner’s Guide to Choosing Your First Vibrator</h1><p><em>Published: March 1, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for A Beginner’s Guide to Choosing Your First Vibrator.</p>
+    <div id="footer"></div>
     <script src="../scripts/include.js" defer></script>
   </body></html>

--- a/bedside/guide-2.html
+++ b/bedside/guide-2.html
@@ -3,7 +3,7 @@
   <meta property="og:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
   <meta name="twitter:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
 </head><body id="top">
-    <div id="navbar"></div><div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>Understanding Discreet Shipping & Privacy</h1><p><em>Published: March 10, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for Understanding Discreet Shipping & Privacy.</p><div class='footer-hero-strip'><p>Discreet Shipping • Inclusive Designs • 100% Comfort Guarantee</p></div>
-<div class='site-footer'><div class='legal'>© 2025 Toys Before Bed™ — Curated for all bodies, every night. Last updated: <span id="last-updated"></span>.</div></div><script>const now=new Date();document.getElementById("last-updated").textContent=now.toLocaleDateString(undefined,{year:'numeric',month:'long'});</script>    <div id="footer"></div>
+    <div id="navbar"></div><div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>Understanding Discreet Shipping & Privacy</h1><p><em>Published: March 10, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for Understanding Discreet Shipping & Privacy.</p>
+    <div id="footer"></div>
     <script src="../scripts/include.js" defer></script>
   </body></html>

--- a/bedside/guide-3.html
+++ b/bedside/guide-3.html
@@ -3,7 +3,7 @@
   <meta property="og:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
   <meta name="twitter:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
 </head><body id="top">
-    <div id="navbar"></div><div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>Couples’ Toys: How to Explore Together</h1><p><em>Published: March 20, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for Couples’ Toys: How to Explore Together.</p><div class='footer-hero-strip'><p>Discreet Shipping • Inclusive Designs • 100% Comfort Guarantee</p></div>
-<div class='site-footer'><div class='legal'>© 2025 Toys Before Bed™ — Curated for all bodies, every night. Last updated: <span id="last-updated"></span>.</div></div><script>const now=new Date();document.getElementById("last-updated").textContent=now.toLocaleDateString(undefined,{year:'numeric',month:'long'});</script>    <div id="footer"></div>
+    <div id="navbar"></div><div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>Couples’ Toys: How to Explore Together</h1><p><em>Published: March 20, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for Couples’ Toys: How to Explore Together.</p>
+    <div id="footer"></div>
     <script src="../scripts/include.js" defer></script>
   </body></html>

--- a/blog/post-1.html
+++ b/blog/post-1.html
@@ -33,9 +33,9 @@
   <div class="card">
     <h3>Recent Posts</h3>
     <ul class="recent-posts">
-      <li><a href="post-1.html">Confidence After Dark: The Art of Relaxation</a></li>
-      <li><a href="post-2.html">Designing Intimacy: Gender-Neutral Comfort</a></li>
-      <li><a href="post-3.html">Discretion & Delight: Shipping You Can Trust</a></li>
+      <li><a href="/blog/post-1.html">Confidence After Dark: The Art of Relaxation</a></li>
+      <li><a href="/blog/post-2.html">Designing Intimacy: Gender-Neutral Comfort</a></li>
+      <li><a href="/blog/post-3.html">Discretion & Delight: Shipping You Can Trust</a></li>
     </ul>
   </div>
 

--- a/blog/post-2.html
+++ b/blog/post-2.html
@@ -33,7 +33,7 @@
       <div class="card">
         <h3>Recent Posts</h3>
         <ul style="list-style:none;padding:0;">
-<li><a href="post-1.html" style="color:#7c0e0c;">Confidence After Dark: The Art of Relaxation</a></li><li><a href="post-3.html" style="color:#7c0e0c;">Discretion & Delight: Shipping You Can Trust</a></li></ul>
+<li><a href="/blog/post-1.html" style="color:#7c0e0c;">Confidence After Dark: The Art of Relaxation</a></li><li><a href="/blog/post-3.html" style="color:#7c0e0c;">Discretion & Delight: Shipping You Can Trust</a></li></ul>
       </div>
       <div class="card">
         <h3>Categories</h3>

--- a/blog/post-3.html
+++ b/blog/post-3.html
@@ -33,7 +33,7 @@
       <div class="card">
         <h3>Recent Posts</h3>
         <ul style="list-style:none;padding:0;">
-<li><a href="post-1.html" style="color:#7c0e0c;">Confidence After Dark: The Art of Relaxation</a></li><li><a href="post-2.html" style="color:#7c0e0c;">Designing Intimacy: Gender‑Neutral Comfort</a></li></ul>
+<li><a href="/blog/post-1.html" style="color:#7c0e0c;">Confidence After Dark: The Art of Relaxation</a></li><li><a href="/blog/post-2.html" style="color:#7c0e0c;">Designing Intimacy: Gender‑Neutral Comfort</a></li></ul>
       </div>
       <div class="card">
         <h3>Categories</h3>

--- a/contact.html
+++ b/contact.html
@@ -9,7 +9,7 @@
 <main class="page"><div class="container">
 <h2>Contact Us</h2><p>We’ll reply within 1–2 business days.</p><form onsubmit="alert('Message sent! We’ll be in touch.');trackEvent('form_submit','contact');return false;"><input placeholder='Your Name' required><input type='email' placeholder='Email' required><textarea placeholder='Your message' required></textarea><button class='btn primary'>Send</button></form></div></main>
 
-<div class='footer-hero-strip'><p>Discreet Shipping • Inclusive Designs • 100% Comfort Guarantee</p></div>
+
     <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
   </body></html>

--- a/faq.html
+++ b/faq.html
@@ -9,7 +9,7 @@
 <main class="page"><div class="container">
 <h2>FAQ</h2><details open><summary>Is shipping discreet?</summary><p>Yes — all orders ship in plain, unmarked packaging. 100% private.</p></details><details><summary>Do you offer free shipping?</summary><p>Yes — free shipping on orders over $50 (US) and £40+ (UK).</p></details><details><summary>Can I return items?</summary><p>Most items are final sale. Faulty products will be replaced or refunded.</p></details></div></main>
 
-<div class='footer-hero-strip'><p>Discreet Shipping • Inclusive Designs • 100% Comfort Guarantee</p></div>
+
     <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
   </body></html>

--- a/includes/breadcrumbs.html
+++ b/includes/breadcrumbs.html
@@ -1,0 +1,1 @@
+<div id="breadcrumbs"></div>

--- a/includes/footer.html
+++ b/includes/footer.html
@@ -1,8 +1,5 @@
-<div class="footer-hero-strip">
-  <p>Discreet Shipping • Inclusive Designs • 100% Comfort Guarantee</p>
-</div>
-
-<footer class="footer">
+<footer>
+  <p class="tagline">Discreet Shipping • Inclusive Designs • 100% Comfort Guarantee</p>
   <p class="footer-links">
     <a href="/index.html">Home</a>
     <a href="/about.html">About</a>

--- a/includes/navbar.html
+++ b/includes/navbar.html
@@ -5,13 +5,13 @@
 
 <nav class="navbar">
   <ul class="nav-list">
-    <li><a href="index.html">Home</a></li>
-    <li><a href="about.html">About</a></li>
-    <li><a href="join.html">Join Us</a></li>
-    <li><a href="faq.html">FAQ</a></li>
-    <li><a href="contact.html">Contact</a></li>
-    <li><a href="privacy.html">Privacy</a></li>
-    <li><a href="terms.html">Terms</a></li>
+    <li><a href="/index.html">Home</a></li>
+    <li><a href="/about.html">About</a></li>
+    <li><a href="/join.html">Join Us</a></li>
+    <li><a href="/faq.html">FAQ</a></li>
+    <li><a href="/contact.html">Contact</a></li>
+    <li><a href="/privacy.html">Privacy</a></li>
+    <li><a href="/terms.html">Terms</a></li>
   </ul>
 </nav>
 

--- a/privacy-uk.html
+++ b/privacy-uk.html
@@ -9,7 +9,7 @@
 <main class="page"><div class="container">
 <h2>Privacy Policy (UK & EU GDPR)</h2><p>We comply with GDPR. You may request access, correction, or deletion of your data at any time.</p></div></main>
 
-<div class='footer-hero-strip'><p>Discreet Shipping • Inclusive Designs • 100% Comfort Guarantee</p></div>
+
     <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
   </body></html>

--- a/privacy.html
+++ b/privacy.html
@@ -9,7 +9,7 @@
 <main class="page"><div class="container">
 <h2>Privacy Policy (US)</h2><p>We respect your privacy. We collect minimal data to fulfill orders, provide customer support, and comply with US laws (CCPA, etc.). We never sell your data.</p></div></main>
 
-<div class='footer-hero-strip'><p>Discreet Shipping • Inclusive Designs • 100% Comfort Guarantee</p></div>
+
     <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
   </body></html>

--- a/products/toy-a.html
+++ b/products/toy-a.html
@@ -13,7 +13,7 @@
     <img src="../assets/products/placeholder-1.jpg" alt="Placeholder image for Discreet Vibrator" style="max-width:400px;width:100%;border-radius:12px;margin:20px 0;">
     <p style="font-size:1.1rem;max-width:700px;margin:auto;">A sleek and discreet vibrator designed for comfort and confidence. Perfect for beginners or those who value privacy. Coming soon.</p>
     <p style="margin-top:20px;">
-      <a href="../index.html" class="btn-primary">Back to Store</a>
+      <a href="/index.html" class="btn-primary">Back to Store</a>
     </p>
   </main>
 

--- a/products/toy-b.html
+++ b/products/toy-b.html
@@ -13,7 +13,7 @@
     <img src="../assets/products/placeholder-2.jpg" alt="Placeholder image for Couples’ Kit" style="max-width:400px;width:100%;border-radius:12px;margin:20px 0;">
     <p style="font-size:1.1rem;max-width:700px;margin:auto;">An intimate kit designed for couples to explore together. Includes a variety of essentials for shared experiences. Coming soon.</p>
     <p style="margin-top:20px;">
-      <a href="../index.html" class="btn-primary">Back to Store</a>
+      <a href="/index.html" class="btn-primary">Back to Store</a>
     </p>
   </main>
 

--- a/products/toy-c.html
+++ b/products/toy-c.html
@@ -13,7 +13,7 @@
     <img src="../assets/products/placeholder-3.jpg" alt="Placeholder image for Massage Oil" style="max-width:400px;width:100%;border-radius:12px;margin:20px 0;">
     <p style="font-size:1.1rem;max-width:700px;margin:auto;">Luxurious massage oil with a silky finish, perfect for relaxation and connection. Coming soon.</p>
     <p style="margin-top:20px;">
-      <a href="../index.html" class="btn-primary">Back to Store</a>
+      <a href="/index.html" class="btn-primary">Back to Store</a>
     </p>
   </main>
 

--- a/products/toy-d.html
+++ b/products/toy-d.html
@@ -13,7 +13,7 @@
     <img src="../assets/products/placeholder-4.jpg" alt="Placeholder image for Wand Vibrator" style="max-width:400px;width:100%;border-radius:12px;margin:20px 0;">
     <p style="font-size:1.1rem;max-width:700px;margin:auto;">Powerful wand massager for deep, soothing sensations. A must‑have for your collection. Coming soon.</p>
     <p style="margin-top:20px;">
-      <a href="../index.html" class="btn-primary">Back to Store</a>
+      <a href="/index.html" class="btn-primary">Back to Store</a>
     </p>
   </main>
 

--- a/products/toy-e.html
+++ b/products/toy-e.html
@@ -13,7 +13,7 @@
     <img src="../assets/products/placeholder-5.jpg" alt="Placeholder image for Luxury Toy" style="max-width:400px;width:100%;border-radius:12px;margin:20px 0;">
     <p style="font-size:1.1rem;max-width:700px;margin:auto;">Premium crafted toy for those who seek elegance and performance. Coming soon.</p>
     <p style="margin-top:20px;">
-      <a href="../index.html" class="btn-primary">Back to Store</a>
+      <a href="/index.html" class="btn-primary">Back to Store</a>
     </p>
   </main>
 

--- a/products/toy-f.html
+++ b/products/toy-f.html
@@ -13,7 +13,7 @@
     <img src="../assets/products/placeholder-6.jpg" alt="Placeholder image for Lube Gel" style="max-width:400px;width:100%;border-radius:12px;margin:20px 0;">
     <p style="font-size:1.1rem;max-width:700px;margin:auto;">High‑quality lubricant for comfort, confidence, and pleasure. Coming soon.</p>
     <p style="margin-top:20px;">
-      <a href="../index.html" class="btn-primary">Back to Store</a>
+      <a href="/index.html" class="btn-primary">Back to Store</a>
     </p>
   </main>
 

--- a/returns.html
+++ b/returns.html
@@ -9,7 +9,7 @@
 <main class="page"><div class="container">
 <h2>Returns Policy</h2><p>Due to the intimate nature of our products, most sales are final. Faulty products will be replaced or refunded.</p></div></main>
 
-<div class='footer-hero-strip'><p>Discreet Shipping • Inclusive Designs • 100% Comfort Guarantee</p></div>
+
     <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
   </body></html>

--- a/scripts/include.js
+++ b/scripts/include.js
@@ -4,12 +4,47 @@ document.addEventListener("DOMContentLoaded", () => {
   const depth = window.location.pathname.split("/").length - 2;
   const basePath = depth > 0 ? "../".repeat(depth) : "./";
 
+  function generateBreadcrumbs() {
+    const path = window.location.pathname.replace(/\/$/, "");
+    const segments = path.split("/").filter(p => p && p !== "index.html");
+    const bc = document.getElementById("breadcrumbs");
+    if (!bc) return;
+
+    let html = `<a href="/index.html">Home</a>`;
+    let cumulative = "";
+    segments.forEach((seg, idx) => {
+      cumulative += "/" + seg;
+      const label = decodeURIComponent(seg)
+        .replace(/\.html$/, "")
+        .split("-")
+        .map(s => s.charAt(0).toUpperCase() + s.slice(1))
+        .join(" ");
+      if (idx < segments.length - 1) {
+        html += `<span>&gt;</span><a href="${cumulative}">${label}</a>`;
+      } else {
+        html += `<span>&gt;</span>${label}`;
+      }
+    });
+    bc.innerHTML = html;
+  }
+
   // Load Navbar
   fetch(basePath + "includes/navbar.html")
     .then(res => res.text())
     .then(html => {
       const container = document.getElementById("navbar");
-      if (container) container.innerHTML = html;
+      if (container) {
+        container.innerHTML = html;
+
+        // Inject breadcrumbs placeholder
+        fetch(basePath + "includes/breadcrumbs.html")
+          .then(res => res.text())
+          .then(bcHtml => {
+            container.insertAdjacentHTML("afterend", bcHtml);
+            generateBreadcrumbs();
+          })
+          .catch(err => console.error("Breadcrumb load error:", err));
+      }
     })
     .catch(err => console.error("Navbar load error:", err));
 

--- a/scripts/verify-includes.js
+++ b/scripts/verify-includes.js
@@ -46,7 +46,12 @@ function checkLinks(filePath, html, depth) {
   while ((match = regex.exec(html))) {
     const href = match[1];
     if (href.startsWith("http") || href.startsWith("#")) continue; // skip external/anchors
-    const relPath = depth === 0 ? href : path.join("..", href);
+    let relPath;
+    if (href.startsWith("/")) {
+      relPath = href.slice(1);
+    } else {
+      relPath = depth === 0 ? href : path.join("..", href);
+    }
     if (!fileExists(relPath)) {
       brokenLinks.push(`${filePath}: Broken link → ${href}`);
     }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -491,3 +491,46 @@ nav a:hover {
   text-decoration: underline; /* underline only on hover */
   color: #5a0a0a;            /* darker maroon hover */
 }
+
+/* Breadcrumb Styling */
+#breadcrumbs {
+  font-family: 'Crimson Text', serif;
+  margin: 10px 20px;
+  padding: 8px 12px;
+  background: #f9f4f4;
+  border-radius: 4px;
+  font-size: 0.95rem;
+}
+#breadcrumbs a {
+  color: #7c0e0c;
+  text-decoration: none;
+  font-weight: 600;
+}
+#breadcrumbs a:hover {
+  text-decoration: underline;
+}
+#breadcrumbs span {
+  margin: 0 5px;
+  color: #555;
+}
+
+/* Footer Fix */
+footer {
+  background-color: #7c0e0c;
+  color: #fff;
+  padding: 20px 10px;
+  text-align: center;
+}
+footer a {
+  color: #fff;
+  text-decoration: none;
+  margin: 0 8px;
+  font-weight: 500;
+}
+footer a:hover {
+  text-decoration: underline;
+}
+footer .tagline {
+  font-weight: 600;
+  margin-bottom: 10px;
+}

--- a/terms.html
+++ b/terms.html
@@ -9,7 +9,7 @@
 <main class="page"><div class="container">
 <h2>Terms of Use</h2><p>You must be 18+ to view or purchase. All content and products are © Toys Before Bed™. Do not redistribute without permission.</p></div></main>
 
-<div class='footer-hero-strip'><p>Discreet Shipping • Inclusive Designs • 100% Comfort Guarantee</p></div>
+
     <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
   </body></html>

--- a/thank-you.html
+++ b/thank-you.html
@@ -24,14 +24,10 @@
 <main style="padding:40px;max-width:800px;margin:auto;text-align:center;">
     <h1 style="color:#7c0e0c;">Thank You for Subscribing! 💌</h1>
     <p>We’re so excited to have you join the Toys Before Bed™ community. Keep an eye on your inbox for our upcoming stories, tips, and exclusive deals.</p>
-    <p><a href="index.html" class="btn-primary">Return to Home</a></p>
+    <p><a href="/index.html" class="btn-primary">Return to Home</a></p>
   </main>
 
-  <div class="site-footer">
-    <div class="legal">© 2025 Toys Before Bed™ — Curated for all bodies, every night.<br>
-      Last updated: August 31, 2025.
-    </div>
-  </div>
+  
     <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
   </body>


### PR DESCRIPTION
## Summary
- Consolidate footer into a single block with root-relative links and tagline
- Generate styled breadcrumb navigation from URL paths
- Update scripts and pages to remove duplicate footers and ensure consistent navigation

## Testing
- `node scripts/verify-includes.js`

------
https://chatgpt.com/codex/tasks/task_e_68b65092ffa48326b2822e07bc2e76aa