### PR TITLE
Remove comfort guarantee from footer tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Deployed via **GitHub Pages** at: [https://toysbeforebed.com](https://toysbefore
 - ✅ Polished hero banner (1920×700, WebP + JPG fallback) with parallax + zoom + fade animations  
 - ✅ 6 product placeholders (400×400) with **descriptive alt text** for accessibility + SEO  
 - ✅ Responsive layout (desktop + mobile)  
-- ✅ Footer trust strip: *Discreet Shipping • Inclusive Designs • 100% Comfort Guarantee*  
+- ✅ Footer trust strip: *Discreet Shipping • Inclusive Designs*
 - ✅ Dynamic “Last Updated” footer date  
 
 **Last site update:** August 31, 2025  

--- a/includes/footer.html
+++ b/includes/footer.html
@@ -1,5 +1,5 @@
 <footer>
-  <p class="tagline">Discreet Shipping • Inclusive Designs • 100% Comfort Guarantee</p>
+  <p class="tagline">Discreet Shipping • Inclusive Designs</p>
   <p class="footer-links">
     <a href="/index.html">Home</a>
     <a href="/about.html">About</a>


### PR DESCRIPTION
## Summary
- drop "100% Comfort Guarantee" from the global footer tagline
- update README to reflect new tagline

## Testing
- `node scripts/verify-includes.js`
- `node scripts/sitemap-generator.js`

------
https://chatgpt.com/codex/tasks/task_e_68b6544a1f008326a9e112f0987f7b20