### PR TITLE
Remove breadcrumbs from sitemap and thank-you pages

### DIFF
--- a/scripts/include.js
+++ b/scripts/include.js
@@ -35,4 +35,13 @@ document.addEventListener("DOMContentLoaded", () => {
       }
     })
     .catch(err => console.error("Footer load error:", err));
+
+  // Skip breadcrumbs on specific pages
+  const page = window.location.pathname.split("/").pop();
+  if (page === "sitemap.html" || page === "thank-you.html") {
+    const crumbs = document.querySelector(".breadcrumbs");
+    if (crumbs) {
+      crumbs.remove();
+    }
+  }
 });

--- a/sitemap.html
+++ b/sitemap.html
@@ -8,8 +8,6 @@
 </head>
 <body id="top">
   <div id="navbar"></div>
-  <!-- Breadcrumbs Navigation -->
-  <nav class="breadcrumbs"><a href="/index.html">Home</a> › <span>Sitemap</span></nav>
   <main class="container">
     <h1>Sitemap</h1>
     <ul>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -514,6 +514,9 @@ nav a:hover {
     color: #555;
     font-weight: 400;
   }
+  .breadcrumbs:empty {
+    display: none;
+  }
 
   <!-- Product Card Button Styling -->
   /* ------------------------------

--- a/thank-you.html
+++ b/thank-you.html
@@ -20,9 +20,6 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
-    <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumbs"><a href="/index.html">Home</a> › <span>Thank You</span></nav>
-
 <main style="padding:40px;max-width:800px;margin:auto;text-align:center;">
     <h1 style="color:#7c0e0c;">Thank You for Subscribing! 💌</h1>
     <p>We’re so excited to have you join the Toys Before Bed™ community. Keep an eye on your inbox for our upcoming stories, tips, and exclusive deals.</p>


### PR DESCRIPTION
## Summary
- Skip rendering breadcrumbs on sitemap and thank-you pages
- Add CSS safeguard to hide empty breadcrumb containers
- Strip static breadcrumb markup from sitemap and thank-you pages

## Testing
- `node scripts/verify-includes.js`


------
https://chatgpt.com/codex/tasks/task_e_68b65ca0d28883268c7494e7c64876ec