### PR TITLE
Exclude breadcrumbs on non-breadcrumb pages and mark in sitemap

### DIFF
--- a/scripts/include.js
+++ b/scripts/include.js
@@ -37,8 +37,9 @@ document.addEventListener("DOMContentLoaded", () => {
     .catch(err => console.error("Footer load error:", err));
 
   // Skip breadcrumbs on specific pages
-  const page = window.location.pathname.split("/").pop();
-  if (page === "sitemap.html" || page === "thank-you.html") {
+  const noBreadcrumbs = ["sitemap.html", "thank-you.html"];
+  const currentPage = window.location.pathname.split("/").pop();
+  if (noBreadcrumbs.includes(currentPage)) {
     const crumbs = document.querySelector(".breadcrumbs");
     if (crumbs) {
       crumbs.remove();

--- a/scripts/sitemap-generator.js
+++ b/scripts/sitemap-generator.js
@@ -23,11 +23,17 @@ function getHtmlFiles(dir) {
 
 const htmlFiles = getHtmlFiles(rootDir).sort();
 
+const noBreadcrumbs = ['sitemap.html', 'thank-you.html'];
+
 const listItems = htmlFiles
   .map(file => {
     const urlPath = '/' + file.replace(/\\/g, '/');
     const url = BASE_URL + urlPath;
-    return `      <li><a href="${url}">${url}</a></li>`;
+    const fileName = path.basename(file);
+    const breadcrumbAttr = noBreadcrumbs.includes(fileName)
+      ? ' data-breadcrumbs="false"'
+      : '';
+    return `      <li><a href="${url}"${breadcrumbAttr}>${url}</a></li>`;
   })
   .join('\n');
 

--- a/sitemap.html
+++ b/sitemap.html
@@ -34,9 +34,9 @@
       <li><a href="https://toysbeforebed.com/products/toy-e.html">https://toysbeforebed.com/products/toy-e.html</a></li>
       <li><a href="https://toysbeforebed.com/products/toy-f.html">https://toysbeforebed.com/products/toy-f.html</a></li>
       <li><a href="https://toysbeforebed.com/returns.html">https://toysbeforebed.com/returns.html</a></li>
-      <li><a href="https://toysbeforebed.com/sitemap.html">https://toysbeforebed.com/sitemap.html</a></li>
+      <li><a href="https://toysbeforebed.com/sitemap.html" data-breadcrumbs="false">https://toysbeforebed.com/sitemap.html</a></li>
       <li><a href="https://toysbeforebed.com/terms.html">https://toysbeforebed.com/terms.html</a></li>
-      <li><a href="https://toysbeforebed.com/thank-you.html">https://toysbeforebed.com/thank-you.html</a></li>
+      <li><a href="https://toysbeforebed.com/thank-you.html" data-breadcrumbs="false">https://toysbeforebed.com/thank-you.html</a></li>
     </ul>
   </main>
   <div id="footer"></div>

--- a/styles.css
+++ b/styles.css
@@ -101,3 +101,8 @@ footer {
   width: 150px;
   cursor: pointer;
 }
+
+/* Hide breadcrumbs if present but empty */
+.breadcrumbs:empty {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- Skip breadcrumb injection on `sitemap.html` and `thank-you.html`
- Hide empty breadcrumb bar with CSS safeguard
- Mark sitemap entries for pages without breadcrumbs

## Testing
- `node scripts/sitemap-generator.js`
- `node scripts/verify-includes.js` *(reports existing broken link warnings for product links)*

------
https://chatgpt.com/codex/tasks/task_e_68b65db187288326b3a9e088f30ab405