### PR TITLE
Add themed breadcrumb navigation

### DIFF
--- a/bedside.html
+++ b/bedside.html
@@ -36,7 +36,7 @@
 <body id="top">
     <div id="navbar"></div>
     <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumbs"><a href="/index.html">Home</a> › <span>Bedside Reading</span></nav>
+    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <span>Bedside Reading</span></nav>
   <main class="page">
     <div class="container">
       <h1>Bedside Reading</h1>

--- a/bedside/guide-1.html
+++ b/bedside/guide-1.html
@@ -5,7 +5,7 @@
 </head><body id="top">
     <div id="navbar"></div>
     <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumbs"><a href="/index.html">Home</a> › <a href="/bedside.html">Bedside</a> › <span>Guide 1</span></nav><div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>A Beginner’s Guide to Choosing Your First Vibrator</h1><p><em>Published: March 1, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for A Beginner’s Guide to Choosing Your First Vibrator.</p>
+    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <a href="/bedside.html">Bedside Reading</a> <span class="separator">></span> <span>Guide 1</span></nav><div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>A Beginner’s Guide to Choosing Your First Vibrator</h1><p><em>Published: March 1, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for A Beginner’s Guide to Choosing Your First Vibrator.</p>
     <div id="footer"></div>
     <script src="../scripts/include.js" defer></script>
   </body></html>

--- a/bedside/guide-2.html
+++ b/bedside/guide-2.html
@@ -5,7 +5,7 @@
 </head><body id="top">
     <div id="navbar"></div>
     <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumbs"><a href="/index.html">Home</a> › <a href="/bedside.html">Bedside</a> › <span>Guide 2</span></nav><div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>Understanding Discreet Shipping & Privacy</h1><p><em>Published: March 10, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for Understanding Discreet Shipping & Privacy.</p>
+    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <a href="/bedside.html">Bedside Reading</a> <span class="separator">></span> <span>Guide 2</span></nav><div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>Understanding Discreet Shipping & Privacy</h1><p><em>Published: March 10, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for Understanding Discreet Shipping & Privacy.</p>
     <div id="footer"></div>
     <script src="../scripts/include.js" defer></script>
   </body></html>

--- a/bedside/guide-3.html
+++ b/bedside/guide-3.html
@@ -5,7 +5,7 @@
 </head><body id="top">
     <div id="navbar"></div>
     <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumbs"><a href="/index.html">Home</a> › <a href="/bedside.html">Bedside</a> › <span>Guide 3</span></nav><div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>Couples’ Toys: How to Explore Together</h1><p><em>Published: March 20, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for Couples’ Toys: How to Explore Together.</p>
+    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <a href="/bedside.html">Bedside Reading</a> <span class="separator">></span> <span>Guide 3</span></nav><div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>Couples’ Toys: How to Explore Together</h1><p><em>Published: March 20, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for Couples’ Toys: How to Explore Together.</p>
     <div id="footer"></div>
     <script src="../scripts/include.js" defer></script>
   </body></html>

--- a/blog.html
+++ b/blog.html
@@ -21,7 +21,7 @@
 <body id="top">
     <div id="navbar"></div>
     <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumbs"><a href="/index.html">Home</a> › <span>Blog</span></nav>
+    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <span>Blog</span></nav>
 
 <main style="padding:40px;max-width:1200px;margin:auto;">
     <h1 style="text-align:center; color:#7c0e0c;">Bedside Reading</h1>

--- a/blog/post-1.html
+++ b/blog/post-1.html
@@ -21,7 +21,7 @@
 <body id="top">
     <div id="navbar"></div>
     <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumbs"><a href="/index.html">Home</a> › <a href="/blog.html">Blog</a> › <span>Post 1</span></nav>
+    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <a href="/blog.html">Blog</a> <span class="separator">></span> <span>Confidence After Dark: The Art of Relaxation</span></nav>
 
 <main style="display:flex;max-width:1200px;margin:auto;padding:40px;gap:30px;flex-wrap:wrap;">
     <article style="flex:1 1 65%;min-width:280px;">

--- a/blog/post-2.html
+++ b/blog/post-2.html
@@ -21,7 +21,7 @@
 <body id="top">
     <div id="navbar"></div>
     <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumbs"><a href="/index.html">Home</a> › <a href="/blog.html">Blog</a> › <span>Post 2</span></nav>
+    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <a href="/blog.html">Blog</a> <span class="separator">></span> <span>Designing Intimacy: Gender‑Neutral Comfort</span></nav>
 
 <main style="display:flex;max-width:1200px;margin:auto;padding:40px;gap:30px;flex-wrap:wrap;">
     <article style="flex:1 1 65%;min-width:280px;">

--- a/blog/post-3.html
+++ b/blog/post-3.html
@@ -21,7 +21,7 @@
 <body id="top">
     <div id="navbar"></div>
     <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumbs"><a href="/index.html">Home</a> › <a href="/blog.html">Blog</a> › <span>Post 3</span></nav>
+    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <a href="/blog.html">Blog</a> <span class="separator">></span> <span>Discretion & Delight: Shipping You Can Trust</span></nav>
 
 <main style="display:flex;max-width:1200px;margin:auto;padding:40px;gap:30px;flex-wrap:wrap;">
     <article style="flex:1 1 65%;min-width:280px;">

--- a/products/toy-a.html
+++ b/products/toy-a.html
@@ -8,7 +8,7 @@
 <body id="top">
     <div id="navbar"></div>
     <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumbs"><a href="/index.html">Home</a> › <a href="/index.html">Products</a> › <span>Toy A</span></nav>
+    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <a href="/index.html#products">Products</a> <span class="separator">></span> <span>Discreet Vibrator</span></nav>
 
 <main style="padding:40px;max-width:1000px;margin:auto;text-align:center;">
     <h1>Discreet Vibrator</h1>

--- a/products/toy-b.html
+++ b/products/toy-b.html
@@ -8,7 +8,7 @@
 <body id="top">
     <div id="navbar"></div>
     <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumbs"><a href="/index.html">Home</a> › <a href="/index.html">Products</a> › <span>Toy B</span></nav>
+    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <a href="/index.html#products">Products</a> <span class="separator">></span> <span>Couples’ Kit</span></nav>
 
 <main style="padding:40px;max-width:1000px;margin:auto;text-align:center;">
     <h1>Couples’ Kit</h1>

--- a/products/toy-c.html
+++ b/products/toy-c.html
@@ -8,7 +8,7 @@
 <body id="top">
     <div id="navbar"></div>
     <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumbs"><a href="/index.html">Home</a> › <a href="/index.html">Products</a> › <span>Toy C</span></nav>
+    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <a href="/index.html#products">Products</a> <span class="separator">></span> <span>Massage Oil</span></nav>
 
 <main style="padding:40px;max-width:1000px;margin:auto;text-align:center;">
     <h1>Massage Oil</h1>

--- a/products/toy-d.html
+++ b/products/toy-d.html
@@ -8,7 +8,7 @@
 <body id="top">
     <div id="navbar"></div>
     <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumbs"><a href="/index.html">Home</a> › <a href="/index.html">Products</a> › <span>Toy D</span></nav>
+    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <a href="/index.html#products">Products</a> <span class="separator">></span> <span>Wand Vibrator</span></nav>
 
 <main style="padding:40px;max-width:1000px;margin:auto;text-align:center;">
     <h1>Wand Vibrator</h1>

--- a/products/toy-e.html
+++ b/products/toy-e.html
@@ -8,7 +8,7 @@
 <body id="top">
     <div id="navbar"></div>
     <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumbs"><a href="/index.html">Home</a> › <a href="/index.html">Products</a> › <span>Toy E</span></nav>
+    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <a href="/index.html#products">Products</a> <span class="separator">></span> <span>Luxury Toy</span></nav>
 
 <main style="padding:40px;max-width:1000px;margin:auto;text-align:center;">
     <h1>Luxury Toy</h1>

--- a/products/toy-f.html
+++ b/products/toy-f.html
@@ -8,7 +8,7 @@
 <body id="top">
     <div id="navbar"></div>
     <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumbs"><a href="/index.html">Home</a> › <a href="/index.html">Products</a> › <span>Toy F</span></nav>
+    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <a href="/index.html#products">Products</a> <span class="separator">></span> <span>Lube Gel</span></nav>
 
 <main style="padding:40px;max-width:1000px;margin:auto;text-align:center;">
     <h1>Lube Gel</h1>

--- a/scripts/include.js
+++ b/scripts/include.js
@@ -21,7 +21,7 @@ document.addEventListener("DOMContentLoaded", () => {
     if (path.includes("/blog/")) {
       crumbs.push(`<a href="${basePath}blog.html">Blog</a>`);
     } else if (path.includes("/bedside/")) {
-      crumbs.push(`<a href="${basePath}bedside.html">Bedside</a>`);
+      crumbs.push(`<a href="${basePath}bedside.html">Bedside Reading</a>`);
     } else if (path.includes("/products/")) {
       crumbs.push(`<a href="${basePath}index.html#products">Products</a>`);
     }
@@ -29,7 +29,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const pageTitle = document.title.split("|")[0].trim();
     crumbs.push(`<span>${pageTitle}</span>`);
 
-    el.innerHTML = crumbs.join('<span>›</span>');
+    el.innerHTML = crumbs.join('<span class="separator">&gt;</span>');
   }
 
   // Load Navbar
@@ -83,7 +83,7 @@ document.addEventListener("DOMContentLoaded", () => {
   ];
 
   const currentPage = window.location.pathname.split("/").pop() || "index.html";
-  const breadcrumbEl = document.querySelector(".breadcrumbs");
+  const breadcrumbEl = document.querySelector(".breadcrumb");
 
   if (noBreadcrumbs.includes(currentPage)) {
     if (breadcrumbEl) breadcrumbEl.remove();

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -492,32 +492,36 @@ nav a:hover {
   color: #5a0a0a;            /* darker maroon hover */
 }
 
-  /* ------------------------------
-     Breadcrumbs Styling
-  ------------------------------ */
-  .breadcrumbs {
-    font-size: 0.9rem;
-    margin: 10px 0;
-    padding: 5px 10px;
-    background-color: #fdf2f2;
-    border-radius: 6px;
-    color: #600;
-  }
-  .breadcrumbs a {
-    color: #600;
-    text-decoration: none;
-  }
-  .breadcrumbs a:hover {
-    text-decoration: underline;
-  }
-  .breadcrumbs span {
-    margin: 0 5px;
-    color: #900;
-  }
-  /* Hide breadcrumbs if present but empty */
-  .breadcrumbs:empty {
-    display: none;
-  }
+/* ------------------------------
+   Breadcrumb
+------------------------------ */
+.breadcrumb {
+  font-family: "Crimson Text", serif;
+  font-size: 0.9rem;
+  color: #fff8f0;
+  background: #7c0e0c;
+  padding: 0.5rem 1rem;
+  margin-bottom: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem;
+}
+.breadcrumb a {
+  color: #fff8f0;
+  text-decoration: none;
+}
+.breadcrumb a:hover {
+  color: #ffd966;
+  text-decoration: underline;
+}
+.breadcrumb .separator {
+  color: #f5e1d4;
+  margin: 0 0.25rem;
+}
+.breadcrumb:empty {
+  display: none;
+}
 
   <!-- Product Card Button Styling -->
   /* ------------------------------


### PR DESCRIPTION
## Summary
- style new `.breadcrumb` component in deep maroon with gold hover links and beige separators
- insert breadcrumb navigation on blog posts, bedside guides and product pages
- update dynamic include script to render new breadcrumb structure

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68bad44f9b7c8326b2328f25ccb50780