### PR TITLE
Add breadcrumb navigation to nested pages

### DIFF
--- a/bedside.html
+++ b/bedside.html
@@ -35,8 +35,6 @@
 
 <body id="top">
     <div id="navbar"></div>
-    <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <span>Bedside Reading</span></nav>
   <main class="page">
     <div class="container">
       <h1>Bedside Reading</h1>

--- a/bedside/guide-1.html
+++ b/bedside/guide-1.html
@@ -4,8 +4,12 @@
   <meta name="twitter:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
 </head><body id="top">
     <div id="navbar"></div>
-    <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <a href="/bedside.html">Bedside Reading</a> <span class="separator">></span> <span>Guide 1</span></nav><div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>A Beginner’s Guide to Choosing Your First Vibrator</h1><p><em>Published: March 1, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for A Beginner’s Guide to Choosing Your First Vibrator.</p>
+<nav class="breadcrumbs">
+  <a href="/index.html">Home</a> › 
+  <a href="/bedside/">Bedside</a> › 
+  A Beginner’s Guide to Choosing Your First Vibrator
+</nav>
+<div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>A Beginner’s Guide to Choosing Your First Vibrator</h1><p><em>Published: March 1, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for A Beginner’s Guide to Choosing Your First Vibrator.</p>
     <div id="footer"></div>
     <script src="../scripts/include.js" defer></script>
   </body></html>

--- a/bedside/guide-2.html
+++ b/bedside/guide-2.html
@@ -4,8 +4,12 @@
   <meta name="twitter:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
 </head><body id="top">
     <div id="navbar"></div>
-    <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <a href="/bedside.html">Bedside Reading</a> <span class="separator">></span> <span>Guide 2</span></nav><div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>Understanding Discreet Shipping & Privacy</h1><p><em>Published: March 10, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for Understanding Discreet Shipping & Privacy.</p>
+<nav class="breadcrumbs">
+  <a href="/index.html">Home</a> › 
+  <a href="/bedside/">Bedside</a> › 
+  Understanding Discreet Shipping & Privacy
+</nav>
+<div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>Understanding Discreet Shipping & Privacy</h1><p><em>Published: March 10, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for Understanding Discreet Shipping & Privacy.</p>
     <div id="footer"></div>
     <script src="../scripts/include.js" defer></script>
   </body></html>

--- a/bedside/guide-3.html
+++ b/bedside/guide-3.html
@@ -4,8 +4,12 @@
   <meta name="twitter:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
 </head><body id="top">
     <div id="navbar"></div>
-    <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <a href="/bedside.html">Bedside Reading</a> <span class="separator">></span> <span>Guide 3</span></nav><div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>Couples’ Toys: How to Explore Together</h1><p><em>Published: March 20, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for Couples’ Toys: How to Explore Together.</p>
+<nav class="breadcrumbs">
+  <a href="/index.html">Home</a> › 
+  <a href="/bedside/">Bedside</a> › 
+  Couples’ Toys: How to Explore Together
+</nav>
+<div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>Couples’ Toys: How to Explore Together</h1><p><em>Published: March 20, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for Couples’ Toys: How to Explore Together.</p>
     <div id="footer"></div>
     <script src="../scripts/include.js" defer></script>
   </body></html>

--- a/blog.html
+++ b/blog.html
@@ -20,9 +20,6 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
-    <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <span>Blog</span></nav>
-
 <main style="padding:40px;max-width:1200px;margin:auto;">
     <h1 style="text-align:center; color:#7c0e0c;">Bedside Reading</h1>
     <div class="grid">

--- a/blog/post-1.html
+++ b/blog/post-1.html
@@ -20,8 +20,11 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
-    <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <a href="/blog.html">Blog</a> <span class="separator">></span> <span>Confidence After Dark: The Art of Relaxation</span></nav>
+<nav class="breadcrumbs">
+  <a href="/index.html">Home</a> › 
+  <a href="/blog/">Blog</a> › 
+  Confidence After Dark: The Art of Relaxation
+</nav>
 
 <main style="display:flex;max-width:1200px;margin:auto;padding:40px;gap:30px;flex-wrap:wrap;">
     <article style="flex:1 1 65%;min-width:280px;">

--- a/blog/post-2.html
+++ b/blog/post-2.html
@@ -20,8 +20,11 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
-    <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <a href="/blog.html">Blog</a> <span class="separator">></span> <span>Designing Intimacy: Gender‑Neutral Comfort</span></nav>
+<nav class="breadcrumbs">
+  <a href="/index.html">Home</a> › 
+  <a href="/blog/">Blog</a> › 
+  Designing Intimacy: Gender‑Neutral Comfort
+</nav>
 
 <main style="display:flex;max-width:1200px;margin:auto;padding:40px;gap:30px;flex-wrap:wrap;">
     <article style="flex:1 1 65%;min-width:280px;">

--- a/blog/post-3.html
+++ b/blog/post-3.html
@@ -20,8 +20,11 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
-    <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <a href="/blog.html">Blog</a> <span class="separator">></span> <span>Discretion & Delight: Shipping You Can Trust</span></nav>
+<nav class="breadcrumbs">
+  <a href="/index.html">Home</a> › 
+  <a href="/blog/">Blog</a> › 
+  Discretion & Delight: Shipping You Can Trust
+</nav>
 
 <main style="display:flex;max-width:1200px;margin:auto;padding:40px;gap:30px;flex-wrap:wrap;">
     <article style="flex:1 1 65%;min-width:280px;">

--- a/products/toy-a.html
+++ b/products/toy-a.html
@@ -7,8 +7,11 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
-    <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <a href="/index.html#products">Products</a> <span class="separator">></span> <span>Discreet Vibrator</span></nav>
+<nav class="breadcrumbs">
+  <a href="/index.html">Home</a> › 
+  <a href="/products/">Products</a> › 
+  Discreet Vibrator
+</nav>
 
 <main style="padding:40px;max-width:1000px;margin:auto;text-align:center;">
     <h1>Discreet Vibrator</h1>

--- a/products/toy-b.html
+++ b/products/toy-b.html
@@ -7,8 +7,11 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
-    <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <a href="/index.html#products">Products</a> <span class="separator">></span> <span>Couples’ Kit</span></nav>
+<nav class="breadcrumbs">
+  <a href="/index.html">Home</a> › 
+  <a href="/products/">Products</a> › 
+  Couples’ Kit
+</nav>
 
 <main style="padding:40px;max-width:1000px;margin:auto;text-align:center;">
     <h1>Couples’ Kit</h1>

--- a/products/toy-c.html
+++ b/products/toy-c.html
@@ -7,8 +7,11 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
-    <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <a href="/index.html#products">Products</a> <span class="separator">></span> <span>Massage Oil</span></nav>
+<nav class="breadcrumbs">
+  <a href="/index.html">Home</a> › 
+  <a href="/products/">Products</a> › 
+  Massage Oil
+</nav>
 
 <main style="padding:40px;max-width:1000px;margin:auto;text-align:center;">
     <h1>Massage Oil</h1>

--- a/products/toy-d.html
+++ b/products/toy-d.html
@@ -7,8 +7,11 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
-    <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <a href="/index.html#products">Products</a> <span class="separator">></span> <span>Wand Vibrator</span></nav>
+<nav class="breadcrumbs">
+  <a href="/index.html">Home</a> › 
+  <a href="/products/">Products</a> › 
+  Wand Vibrator
+</nav>
 
 <main style="padding:40px;max-width:1000px;margin:auto;text-align:center;">
     <h1>Wand Vibrator</h1>

--- a/products/toy-e.html
+++ b/products/toy-e.html
@@ -7,8 +7,11 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
-    <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <a href="/index.html#products">Products</a> <span class="separator">></span> <span>Luxury Toy</span></nav>
+<nav class="breadcrumbs">
+  <a href="/index.html">Home</a> › 
+  <a href="/products/">Products</a> › 
+  Luxury Toy
+</nav>
 
 <main style="padding:40px;max-width:1000px;margin:auto;text-align:center;">
     <h1>Luxury Toy</h1>

--- a/products/toy-f.html
+++ b/products/toy-f.html
@@ -7,8 +7,11 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
-    <!-- Breadcrumbs Navigation -->
-    <nav class="breadcrumb"><a href="/index.html">Home</a> <span class="separator">></span> <a href="/index.html#products">Products</a> <span class="separator">></span> <span>Lube Gel</span></nav>
+<nav class="breadcrumbs">
+  <a href="/index.html">Home</a> › 
+  <a href="/products/">Products</a> › 
+  Lube Gel
+</nav>
 
 <main style="padding:40px;max-width:1000px;margin:auto;text-align:center;">
     <h1>Lube Gel</h1>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -492,35 +492,21 @@ nav a:hover {
   color: #5a0a0a;            /* darker maroon hover */
 }
 
-/* ------------------------------
-   Breadcrumb
------------------------------- */
-.breadcrumb {
-  font-family: "Crimson Text", serif;
+/* Breadcrumb navigation */
+.breadcrumbs {
   font-size: 0.9rem;
-  color: #fff8f0;
-  background: #7c0e0c;
+  margin: 0.5rem 0 1rem;
   padding: 0.5rem 1rem;
-  margin-bottom: 1rem;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.25rem;
+  background: #fff5f5;
+  border-left: 4px solid #7c0e0c;
 }
-.breadcrumb a {
-  color: #fff8f0;
+.breadcrumbs a {
+  color: #7c0e0c;
   text-decoration: none;
-}
-.breadcrumb a:hover {
-  color: #ffd966;
-  text-decoration: underline;
-}
-.breadcrumb .separator {
-  color: #f5e1d4;
   margin: 0 0.25rem;
 }
-.breadcrumb:empty {
-  display: none;
+.breadcrumbs a:hover {
+  text-decoration: underline;
 }
 
   <!-- Product Card Button Styling -->


### PR DESCRIPTION
## Summary
- Replace legacy breadcrumb markup with new styled breadcrumbs for product pages, blog posts, and bedside guides.
- Drop outdated breadcrumbs from blog and bedside landing pages so breadcrumbs only appear on nested content.
- Style breadcrumbs with a light background and maroon accents.

## Testing
- `node scripts/verify-includes.js`
- `rg 'class="breadcrumbs"' -n`


------
https://chatgpt.com/codex/tasks/task_e_68bad666f0948326bd0b4cd8ec9e388c