### PR TITLE
feat: automate sitemap generation

### DIFF
--- a/.github/workflows/update-sitemap.yml
+++ b/.github/workflows/update-sitemap.yml
@@ -5,17 +5,21 @@ on:
     branches: [main]
 
 jobs:
-  update-sitemap:
+  update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
       - run: node scripts/sitemap-generator.js
-      - uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: "chore: auto-update sitemap"
-          file_pattern: sitemap.html sitemap.xml
-          commit_user_name: github-actions[bot]
-          commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com
+      - name: Commit sitemap
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add sitemap.html sitemap.xml
+          git commit -m "chore: update sitemap" || echo "No changes to commit"
+          git push
+

--- a/scripts/sitemap-generator.js
+++ b/scripts/sitemap-generator.js
@@ -2,8 +2,26 @@ const fs = require('fs');
 const path = require('path');
 
 const rootDir = path.resolve(__dirname, '..');
+const domain = 'https://toysbeforebed.com';
 
-function getHtmlFiles(dir) {
+const topLevelPages = [
+  'index.html',
+  'about.html',
+  'join.html',
+  'faq.html',
+  'contact.html',
+  'privacy.html',
+  'privacy-uk.html',
+  'terms.html',
+  'returns.html',
+  '2257.html',
+  'sitemap.html',
+  'thank-you.html'
+];
+
+const contentDirs = ['bedside', 'blog', 'products'];
+
+function getAllHtmlFiles(dir) {
   const entries = fs.readdirSync(dir, { withFileTypes: true });
   let files = [];
   for (const entry of entries) {
@@ -12,27 +30,52 @@ function getHtmlFiles(dir) {
       if (['node_modules', '.git', 'includes', 'scripts'].includes(entry.name)) {
         continue;
       }
-      files = files.concat(getHtmlFiles(res));
+      files = files.concat(getAllHtmlFiles(res));
     } else if (entry.isFile() && entry.name.endsWith('.html')) {
-      files.push(path.relative(rootDir, res));
+      files.push(path.relative(rootDir, res).replace(/\\/g, '/'));
     }
   }
   return files;
 }
 
-const htmlFiles = getHtmlFiles(rootDir).sort();
+function isAllowed(relPath) {
+  if (topLevelPages.includes(relPath)) return true;
+  return contentDirs.some(dir => relPath.startsWith(`${dir}/`));
+}
 
-const noBreadcrumbs = ['sitemap.html', 'thank-you.html'];
+function getTitle(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const match = content.match(/<title>([^<]*)<\/title>/i);
+    return match ? match[1].trim() : null;
+  } catch {
+    return null;
+  }
+}
 
-const listItems = htmlFiles
-  .map(file => {
-    const relPath = file.replace(/\\/g, '/');
-    const fileName = path.basename(file);
-    const breadcrumbAttr = noBreadcrumbs.includes(fileName)
-      ? ' data-breadcrumbs="false"'
-      : '';
-    return `      <li><a href="${relPath}"${breadcrumbAttr}>${relPath}</a></li>`;
-  })
+function getLastMod(filePath) {
+  try {
+    const stats = fs.statSync(filePath);
+    return stats.mtime.toISOString().split('T')[0];
+  } catch {
+    return new Date().toISOString().split('T')[0];
+  }
+}
+
+const htmlFiles = getAllHtmlFiles(rootDir).filter(isAllowed).sort();
+
+const pages = htmlFiles.map(rel => {
+  const full = path.join(rootDir, rel);
+  const title = getTitle(full) || path.basename(rel);
+  let lastmod = getLastMod(full);
+  if (rel === 'sitemap.html') {
+    lastmod = new Date().toISOString().split('T')[0];
+  }
+  return { rel, title, lastmod };
+});
+
+const listItems = pages
+  .map(p => `      <li><a href="/${p.rel}">${p.title}</a></li>`)
   .join('\n');
 
 const sitemapHtml = `<!DOCTYPE html>
@@ -41,32 +84,36 @@ const sitemapHtml = `<!DOCTYPE html>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Sitemap | Toys Before Bed™</title>
-  <link href="styles/styles.css" rel="stylesheet">
+  <link rel="stylesheet" href="/styles/styles.css">
+  <style>
+    ul.sitemap-list { list-style: none; padding-left: 0; }
+    ul.sitemap-list a { color: #7c0e0c; text-decoration: none; }
+    ul.sitemap-list a:hover { color: #ffd9a0; }
+  </style>
 </head>
 <body id="top">
   <div id="navbar"></div>
   <main class="container">
     <h1>Sitemap</h1>
-    <ul>
+    <ul class="sitemap-list">
 ${listItems}
     </ul>
   </main>
   <div id="footer"></div>
-  <script src="scripts/include.js" defer></script>
+  <script src="/scripts/include.js" defer></script>
 </body>
-</html>
-`;
+</html>\n`;
 
-fs.writeFileSync(path.join(rootDir, 'sitemap.html'), sitemapHtml, 'utf-8');
+fs.writeFileSync(path.join(rootDir, 'sitemap.html'), sitemapHtml, 'utf8');
 
-const today = new Date().toISOString().split('T')[0];
 let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';
 xml += '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n';
-htmlFiles.forEach(file => {
-  const relPath = file.replace(/\\/g, '/');
-  xml += `  <url>\n    <loc>${relPath}</loc>\n    <lastmod>${today}</lastmod>\n  </url>\n`;
+pages.forEach(p => {
+  xml += `  <url>\n    <loc>${domain}/${p.rel}</loc>\n    <lastmod>${p.lastmod}</lastmod>\n  </url>\n`;
 });
 xml += '</urlset>\n';
-fs.writeFileSync(path.join(rootDir, 'sitemap.xml'), xml, 'utf-8');
 
-console.log('sitemap.html and sitemap.xml generated.');
+fs.writeFileSync(path.join(rootDir, 'sitemap.xml'), xml, 'utf8');
+
+console.log('sitemap.html and sitemap.xml generated');
+

--- a/sitemap.html
+++ b/sitemap.html
@@ -1,47 +1,48 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<link href="styles/styles.css" rel="stylesheet">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Sitemap | Toys Before Bed™</title>
+  <link rel="stylesheet" href="/styles/styles.css">
+  <style>
+    ul.sitemap-list { list-style: none; padding-left: 0; }
+    ul.sitemap-list a { color: #7c0e0c; text-decoration: none; }
+    ul.sitemap-list a:hover { color: #ffd9a0; }
+  </style>
 </head>
 <body id="top">
   <div id="navbar"></div>
-  <main class="page">
-    <div class="container">
+  <main class="container">
     <h1>Sitemap</h1>
-    <ul>
-      <li><a href="/2257.html">2257.html</a></li>
-      <li><a href="/about.html">about.html</a></li>
-      <li><a href="/bedside.html">bedside.html</a></li>
-      <li><a href="/bedside/guide-1.html">bedside/guide-1.html</a></li>
-      <li><a href="/bedside/guide-2.html">bedside/guide-2.html</a></li>
-      <li><a href="/bedside/guide-3.html">bedside/guide-3.html</a></li>
-      <li><a href="/blog.html">blog.html</a></li>
-      <li><a href="/blog/post-1.html">blog/post-1.html</a></li>
-      <li><a href="/blog/post-2.html">blog/post-2.html</a></li>
-      <li><a href="/blog/post-3.html">blog/post-3.html</a></li>
-      <li><a href="/contact.html">contact.html</a></li>
-      <li><a href="/faq.html">faq.html</a></li>
-      <li><a href="/index.html">index.html</a></li>
-      <li><a href="/join.html">join.html</a></li>
-      <li><a href="/privacy-uk.html">privacy-uk.html</a></li>
-      <li><a href="/privacy.html">privacy.html</a></li>
-      <li><a href="/products/toy-a.html">products/toy-a.html</a></li>
-      <li><a href="/products/toy-b.html">products/toy-b.html</a></li>
-      <li><a href="/products/toy-c.html">products/toy-c.html</a></li>
-      <li><a href="/products/toy-d.html">products/toy-d.html</a></li>
-      <li><a href="/products/toy-e.html">products/toy-e.html</a></li>
-      <li><a href="/products/toy-f.html">products/toy-f.html</a></li>
-      <li><a href="/returns.html">returns.html</a></li>
-      <li><a href="/sitemap.html" data-breadcrumbs="false">sitemap.html</a></li>
-      <li><a href="/terms.html">terms.html</a></li>
-      <li><a href="/thank-you.html" data-breadcrumbs="false">thank-you.html</a></li>
+    <ul class="sitemap-list">
+      <li><a href="/2257.html">Toys Before Bed™</a></li>
+      <li><a href="/about.html">About - Toys Before Bed™</a></li>
+      <li><a href="/bedside/guide-1.html">A Beginner’s Guide to Choosing Your First Vibrator</a></li>
+      <li><a href="/bedside/guide-2.html">Understanding Discreet Shipping & Privacy</a></li>
+      <li><a href="/bedside/guide-3.html">Couples’ Toys: How to Explore Together</a></li>
+      <li><a href="/blog/post-1.html">Confidence After Dark: The Art of Relaxation | Toys Before Bed™</a></li>
+      <li><a href="/blog/post-2.html">Designing Intimacy: Gender‑Neutral Comfort | Toys Before Bed™</a></li>
+      <li><a href="/blog/post-3.html">Discretion & Delight: Shipping You Can Trust | Toys Before Bed™</a></li>
+      <li><a href="/contact.html">Toys Before Bed™</a></li>
+      <li><a href="/faq.html">Toys Before Bed™</a></li>
+      <li><a href="/index.html">Toys Before Bed™ | Confidence After Dark</a></li>
+      <li><a href="/join.html">Join Us - Toys Before Bed™</a></li>
+      <li><a href="/privacy-uk.html">Toys Before Bed™</a></li>
+      <li><a href="/privacy.html">Toys Before Bed™</a></li>
+      <li><a href="/products/toy-a.html">Discreet Vibrator | Toys Before Bed™</a></li>
+      <li><a href="/products/toy-b.html">Couples’ Kit | Toys Before Bed™</a></li>
+      <li><a href="/products/toy-c.html">Massage Oil | Toys Before Bed™</a></li>
+      <li><a href="/products/toy-d.html">Wand Vibrator | Toys Before Bed™</a></li>
+      <li><a href="/products/toy-e.html">Luxury Toy | Toys Before Bed™</a></li>
+      <li><a href="/products/toy-f.html">Lube Gel | Toys Before Bed™</a></li>
+      <li><a href="/returns.html">Toys Before Bed™</a></li>
+      <li><a href="/sitemap.html">Sitemap | Toys Before Bed™</a></li>
+      <li><a href="/terms.html">Toys Before Bed™</a></li>
+      <li><a href="/thank-you.html">Thank You | Toys Before Bed™</a></li>
     </ul>
-    </div>
   </main>
   <div id="footer"></div>
-  <script src="scripts/include.js" defer></script>
+  <script src="/scripts/include.js" defer></script>
 </body>
 </html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,107 +1,99 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>2257.html</loc>
-    <lastmod>2025-09-02</lastmod>
+    <loc>https://toysbeforebed.com/2257.html</loc>
+    <lastmod>2025-09-05</lastmod>
   </url>
   <url>
-    <loc>about.html</loc>
-    <lastmod>2025-09-02</lastmod>
+    <loc>https://toysbeforebed.com/about.html</loc>
+    <lastmod>2025-09-05</lastmod>
   </url>
   <url>
-    <loc>bedside.html</loc>
-    <lastmod>2025-09-02</lastmod>
+    <loc>https://toysbeforebed.com/bedside/guide-1.html</loc>
+    <lastmod>2025-09-05</lastmod>
   </url>
   <url>
-    <loc>bedside/guide-1.html</loc>
-    <lastmod>2025-09-02</lastmod>
+    <loc>https://toysbeforebed.com/bedside/guide-2.html</loc>
+    <lastmod>2025-09-05</lastmod>
   </url>
   <url>
-    <loc>bedside/guide-2.html</loc>
-    <lastmod>2025-09-02</lastmod>
+    <loc>https://toysbeforebed.com/bedside/guide-3.html</loc>
+    <lastmod>2025-09-05</lastmod>
   </url>
   <url>
-    <loc>bedside/guide-3.html</loc>
-    <lastmod>2025-09-02</lastmod>
+    <loc>https://toysbeforebed.com/blog/post-1.html</loc>
+    <lastmod>2025-09-05</lastmod>
   </url>
   <url>
-    <loc>blog.html</loc>
-    <lastmod>2025-09-02</lastmod>
+    <loc>https://toysbeforebed.com/blog/post-2.html</loc>
+    <lastmod>2025-09-05</lastmod>
   </url>
   <url>
-    <loc>blog/post-1.html</loc>
-    <lastmod>2025-09-02</lastmod>
+    <loc>https://toysbeforebed.com/blog/post-3.html</loc>
+    <lastmod>2025-09-05</lastmod>
   </url>
   <url>
-    <loc>blog/post-2.html</loc>
-    <lastmod>2025-09-02</lastmod>
+    <loc>https://toysbeforebed.com/contact.html</loc>
+    <lastmod>2025-09-05</lastmod>
   </url>
   <url>
-    <loc>blog/post-3.html</loc>
-    <lastmod>2025-09-02</lastmod>
+    <loc>https://toysbeforebed.com/faq.html</loc>
+    <lastmod>2025-09-05</lastmod>
   </url>
   <url>
-    <loc>contact.html</loc>
-    <lastmod>2025-09-02</lastmod>
+    <loc>https://toysbeforebed.com/index.html</loc>
+    <lastmod>2025-09-05</lastmod>
   </url>
   <url>
-    <loc>faq.html</loc>
-    <lastmod>2025-09-02</lastmod>
+    <loc>https://toysbeforebed.com/join.html</loc>
+    <lastmod>2025-09-05</lastmod>
   </url>
   <url>
-    <loc>index.html</loc>
-    <lastmod>2025-09-02</lastmod>
+    <loc>https://toysbeforebed.com/privacy-uk.html</loc>
+    <lastmod>2025-09-05</lastmod>
   </url>
   <url>
-    <loc>join.html</loc>
-    <lastmod>2025-09-02</lastmod>
+    <loc>https://toysbeforebed.com/privacy.html</loc>
+    <lastmod>2025-09-05</lastmod>
   </url>
   <url>
-    <loc>privacy-uk.html</loc>
-    <lastmod>2025-09-02</lastmod>
+    <loc>https://toysbeforebed.com/products/toy-a.html</loc>
+    <lastmod>2025-09-05</lastmod>
   </url>
   <url>
-    <loc>privacy.html</loc>
-    <lastmod>2025-09-02</lastmod>
+    <loc>https://toysbeforebed.com/products/toy-b.html</loc>
+    <lastmod>2025-09-05</lastmod>
   </url>
   <url>
-    <loc>products/toy-a.html</loc>
-    <lastmod>2025-09-02</lastmod>
+    <loc>https://toysbeforebed.com/products/toy-c.html</loc>
+    <lastmod>2025-09-05</lastmod>
   </url>
   <url>
-    <loc>products/toy-b.html</loc>
-    <lastmod>2025-09-02</lastmod>
+    <loc>https://toysbeforebed.com/products/toy-d.html</loc>
+    <lastmod>2025-09-05</lastmod>
   </url>
   <url>
-    <loc>products/toy-c.html</loc>
-    <lastmod>2025-09-02</lastmod>
+    <loc>https://toysbeforebed.com/products/toy-e.html</loc>
+    <lastmod>2025-09-05</lastmod>
   </url>
   <url>
-    <loc>products/toy-d.html</loc>
-    <lastmod>2025-09-02</lastmod>
+    <loc>https://toysbeforebed.com/products/toy-f.html</loc>
+    <lastmod>2025-09-05</lastmod>
   </url>
   <url>
-    <loc>products/toy-e.html</loc>
-    <lastmod>2025-09-02</lastmod>
+    <loc>https://toysbeforebed.com/returns.html</loc>
+    <lastmod>2025-09-05</lastmod>
   </url>
   <url>
-    <loc>products/toy-f.html</loc>
-    <lastmod>2025-09-02</lastmod>
+    <loc>https://toysbeforebed.com/sitemap.html</loc>
+    <lastmod>2025-09-05</lastmod>
   </url>
   <url>
-    <loc>returns.html</loc>
-    <lastmod>2025-09-02</lastmod>
+    <loc>https://toysbeforebed.com/terms.html</loc>
+    <lastmod>2025-09-05</lastmod>
   </url>
   <url>
-    <loc>sitemap.html</loc>
-    <lastmod>2025-09-02</lastmod>
-  </url>
-  <url>
-    <loc>terms.html</loc>
-    <lastmod>2025-09-02</lastmod>
-  </url>
-  <url>
-    <loc>thank-you.html</loc>
-    <lastmod>2025-09-02</lastmod>
+    <loc>https://toysbeforebed.com/thank-you.html</loc>
+    <lastmod>2025-09-05</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- add sitemap generator script for HTML and XML with titles and lastmod dates
- generate and style sitemap pages
- workflow updates sitemap on each push to main

## Testing
- `node scripts/sitemap-generator.js`
- `xmllint --noout sitemap.xml` *(fails: xmllint not installed)*
- `python - <<'PY'\nimport xml.etree.ElementTree as ET\nET.parse('sitemap.xml')\nprint('XML parsed')\nPY`

------
https://chatgpt.com/codex/tasks/task_e_68badcd3720c832689c23f1e43412c6c