### PR TITLE
Fix HTML structural issues across site

### DIFF
--- a/2257.html
+++ b/2257.html
@@ -1,16 +1,20 @@
-<!DOCTYPE html><html lang="en"><head>
-<link href="styles/styles.css" rel="stylesheet">
-<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Toys Before Bed™</title>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Crimson+Text:wght@400;600;700&display=swap" rel="stylesheet">
-</head><body id="top">
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link href="styles/styles.css" rel="stylesheet">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Toys Before Bed™</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Crimson+Text:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body id="top">
     <div id="navbar"></div>
 <main class="page"><div class="container">
 <h2>18 U.S.C. §2257 Compliance Notice</h2><p>All models appearing on this website were 18+ at the time of photography. Records required by 18 U.S.C. §2257 are maintained by the custodian of records.</p></div></main>
 
-
     <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
-  </body></html>
+  </body>
+</html>

--- a/bedside/guide-1.html
+++ b/bedside/guide-1.html
@@ -1,10 +1,18 @@
-<!DOCTYPE html><html><head><link href="../styles/styles.css" rel="stylesheet"><title>A Beginner’s Guide to Choosing Your First Vibrator</title>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link href="../styles/styles.css" rel="stylesheet">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>A Beginner’s Guide to Choosing Your First Vibrator</title>
   <meta property="og:url" content="https://toysbeforebed.com/bedside/guide-1.html">
   <meta property="og:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
   <meta name="twitter:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
-</head><body id="top">
+</head>
+<body id="top">
     <div id="navbar"></div>
 <div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>A Beginner’s Guide to Choosing Your First Vibrator</h1><p><em>Published: March 1, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for A Beginner’s Guide to Choosing Your First Vibrator.</p>
     <div id="footer"></div>
     <script src="../scripts/include.js" defer></script>
-  </body></html>
+  </body>
+</html>

--- a/bedside/guide-2.html
+++ b/bedside/guide-2.html
@@ -1,10 +1,18 @@
-<!DOCTYPE html><html><head><link href="../styles/styles.css" rel="stylesheet"><title>Understanding Discreet Shipping & Privacy</title>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link href="../styles/styles.css" rel="stylesheet">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Understanding Discreet Shipping & Privacy</title>
   <meta property="og:url" content="https://toysbeforebed.com/bedside/guide-2.html">
   <meta property="og:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
   <meta name="twitter:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
-</head><body id="top">
+</head>
+<body id="top">
     <div id="navbar"></div>
 <div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>Understanding Discreet Shipping & Privacy</h1><p><em>Published: March 10, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for Understanding Discreet Shipping & Privacy.</p>
     <div id="footer"></div>
     <script src="../scripts/include.js" defer></script>
-  </body></html>
+  </body>
+</html>

--- a/bedside/guide-3.html
+++ b/bedside/guide-3.html
@@ -1,10 +1,18 @@
-<!DOCTYPE html><html><head><link href="../styles/styles.css" rel="stylesheet"><title>Couples’ Toys: How to Explore Together</title>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link href="../styles/styles.css" rel="stylesheet">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Couples’ Toys: How to Explore Together</title>
   <meta property="og:url" content="https://toysbeforebed.com/bedside/guide-3.html">
   <meta property="og:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
   <meta name="twitter:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
-</head><body id="top">
+</head>
+<body id="top">
     <div id="navbar"></div>
 <div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>Couples’ Toys: How to Explore Together</h1><p><em>Published: March 20, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for Couples’ Toys: How to Explore Together.</p>
     <div id="footer"></div>
     <script src="../scripts/include.js" defer></script>
-  </body></html>
+  </body>
+</html>

--- a/contact.html
+++ b/contact.html
@@ -1,16 +1,20 @@
-<!DOCTYPE html><html lang="en"><head>
-<link href="styles/styles.css" rel="stylesheet">
-<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Toys Before Bed™</title>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Crimson+Text:wght@400;600;700&display=swap" rel="stylesheet">
-</head><body id="top">
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link href="styles/styles.css" rel="stylesheet">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Toys Before Bed™</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Crimson+Text:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body id="top">
     <div id="navbar"></div>
 <main class="page"><div class="container">
 <h2>Contact Us</h2><p>We’ll reply within 1–2 business days.</p><form onsubmit="alert('Message sent! We’ll be in touch.');trackEvent('form_submit','contact');return false;"><input placeholder='Your Name' required><input type='email' placeholder='Email' required><textarea placeholder='Your message' required></textarea><button class='btn primary'>Send</button></form></div></main>
 
-
     <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
-  </body></html>
+  </body>
+</html>

--- a/faq.html
+++ b/faq.html
@@ -1,16 +1,20 @@
-<!DOCTYPE html><html lang="en"><head>
-<link href="styles/styles.css" rel="stylesheet">
-<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Toys Before Bed™</title>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Crimson+Text:wght@400;600;700&display=swap" rel="stylesheet">
-</head><body id="top">
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link href="styles/styles.css" rel="stylesheet">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Toys Before Bed™</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Crimson+Text:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body id="top">
     <div id="navbar"></div>
 <main class="page"><div class="container">
 <h2>FAQ</h2><details open><summary>Is shipping discreet?</summary><p>Yes — all orders ship in plain, unmarked packaging. 100% private.</p></details><details><summary>Do you offer free shipping?</summary><p>Yes — free shipping on orders over $50 (US) and £40+ (UK).</p></details><details><summary>Can I return items?</summary><p>Most items are final sale. Faulty products will be replaced or refunded.</p></details></div></main>
 
-
     <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
-  </body></html>
+  </body>
+</html>

--- a/privacy-uk.html
+++ b/privacy-uk.html
@@ -1,16 +1,20 @@
-<!DOCTYPE html><html lang="en"><head>
-<link href="styles/styles.css" rel="stylesheet">
-<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Toys Before Bed™</title>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Crimson+Text:wght@400;600;700&display=swap" rel="stylesheet">
-</head><body id="top">
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link href="styles/styles.css" rel="stylesheet">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Toys Before Bed™</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Crimson+Text:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body id="top">
     <div id="navbar"></div>
 <main class="page"><div class="container">
 <h2>Privacy Policy (UK & EU GDPR)</h2><p>We comply with GDPR. You may request access, correction, or deletion of your data at any time.</p></div></main>
 
-
     <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
-  </body></html>
+  </body>
+</html>

--- a/privacy.html
+++ b/privacy.html
@@ -1,16 +1,20 @@
-<!DOCTYPE html><html lang="en"><head>
-<link href="styles/styles.css" rel="stylesheet">
-<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Toys Before Bed™</title>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Crimson+Text:wght@400;600;700&display=swap" rel="stylesheet">
-</head><body id="top">
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link href="styles/styles.css" rel="stylesheet">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Toys Before Bed™</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Crimson+Text:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body id="top">
     <div id="navbar"></div>
 <main class="page"><div class="container">
 <h2>Privacy Policy (US)</h2><p>We respect your privacy. We collect minimal data to fulfill orders, provide customer support, and comply with US laws (CCPA, etc.). We never sell your data.</p></div></main>
 
-
     <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
-  </body></html>
+  </body>
+</html>

--- a/returns.html
+++ b/returns.html
@@ -1,16 +1,20 @@
-<!DOCTYPE html><html lang="en"><head>
-<link href="styles/styles.css" rel="stylesheet">
-<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Toys Before Bed™</title>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Crimson+Text:wght@400;600;700&display=swap" rel="stylesheet">
-</head><body id="top">
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link href="styles/styles.css" rel="stylesheet">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Toys Before Bed™</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Crimson+Text:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body id="top">
     <div id="navbar"></div>
 <main class="page"><div class="container">
 <h2>Returns Policy</h2><p>Due to the intimate nature of our products, most sales are final. Faulty products will be replaced or refunded.</p></div></main>
 
-
     <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
-  </body></html>
+  </body>
+</html>

--- a/terms.html
+++ b/terms.html
@@ -1,16 +1,20 @@
-<!DOCTYPE html><html lang="en"><head>
-<link href="styles/styles.css" rel="stylesheet">
-<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Toys Before Bed™</title>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Crimson+Text:wght@400;600;700&display=swap" rel="stylesheet">
-</head><body id="top">
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link href="styles/styles.css" rel="stylesheet">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Toys Before Bed™</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Crimson+Text:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body id="top">
     <div id="navbar"></div>
 <main class="page"><div class="container">
 <h2>Terms of Use</h2><p>You must be 18+ to view or purchase. All content and products are © Toys Before Bed™. Do not redistribute without permission.</p></div></main>
 
-
     <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
-  </body></html>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- ensure each HTML page begins with DOCTYPE, html lang, head, charset, and body tags
- add missing metadata and titles for bedside guides and policy pages
- normalize meta charset to UTF-8 across contact and legal pages

## Testing
- `node scripts/verify-includes.js`
- `node - <<'NODE' ...` (custom HTML structure validator)
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bae0405ba88326844ef78552822ca6