### PR TITLE
fix: clean HTML structure

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -16,7 +16,8 @@
 <meta property="og:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Bedside Reading | Toys Before Bed™</title>  <link href="styles/styles.css" rel="stylesheet">
+  <title>Bedside Reading | Toys Before Bed™</title>
+  <link href="styles/styles.css" rel="stylesheet">
 </head>
 <body id="top">
     <div id="navbar"></div>

--- a/blog/post-1.html
+++ b/blog/post-1.html
@@ -16,7 +16,8 @@
 <meta property="og:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Confidence After Dark: The Art of Relaxation | Toys Before Bed™</title>  <link href="../styles/styles.css" rel="stylesheet">
+  <title>Confidence After Dark: The Art of Relaxation | Toys Before Bed™</title>
+  <link href="../styles/styles.css" rel="stylesheet">
 </head>
 <body id="top">
     <div id="navbar"></div>

--- a/blog/post-2.html
+++ b/blog/post-2.html
@@ -16,7 +16,8 @@
 <meta property="og:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Designing Intimacy: Gender‑Neutral Comfort | Toys Before Bed™</title>  <link href="../styles/styles.css" rel="stylesheet">
+  <title>Designing Intimacy: Gender‑Neutral Comfort | Toys Before Bed™</title>
+  <link href="../styles/styles.css" rel="stylesheet">
 </head>
 <body id="top">
     <div id="navbar"></div>

--- a/blog/post-3.html
+++ b/blog/post-3.html
@@ -16,7 +16,8 @@
 <meta property="og:image" content="https://toysbeforebed.com/assets/hero/hero-banner-optimized-v2.jpg">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Discretion & Delight: Shipping You Can Trust | Toys Before Bed™</title>  <link href="../styles/styles.css" rel="stylesheet">
+  <title>Discretion & Delight: Shipping You Can Trust | Toys Before Bed™</title>
+  <link href="../styles/styles.css" rel="stylesheet">
 </head>
 <body id="top">
     <div id="navbar"></div>

--- a/products/toy-a.html
+++ b/products/toy-a.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Discreet Vibrator | Toys Before Bed™</title>  <link href="../styles/styles.css" rel="stylesheet">
+  <title>Discreet Vibrator | Toys Before Bed™</title>
+  <link href="../styles/styles.css" rel="stylesheet">
 </head>
 <body id="top">
     <div id="navbar"></div>

--- a/products/toy-b.html
+++ b/products/toy-b.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Couples’ Kit | Toys Before Bed™</title>  <link href="../styles/styles.css" rel="stylesheet">
+  <title>Couples’ Kit | Toys Before Bed™</title>
+  <link href="../styles/styles.css" rel="stylesheet">
 </head>
 <body id="top">
     <div id="navbar"></div>

--- a/products/toy-c.html
+++ b/products/toy-c.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Massage Oil | Toys Before Bed™</title>  <link href="../styles/styles.css" rel="stylesheet">
+  <title>Massage Oil | Toys Before Bed™</title>
+  <link href="../styles/styles.css" rel="stylesheet">
 </head>
 <body id="top">
     <div id="navbar"></div>

--- a/products/toy-d.html
+++ b/products/toy-d.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Wand Vibrator | Toys Before Bed™</title>  <link href="../styles/styles.css" rel="stylesheet">
+  <title>Wand Vibrator | Toys Before Bed™</title>
+  <link href="../styles/styles.css" rel="stylesheet">
 </head>
 <body id="top">
     <div id="navbar"></div>

--- a/products/toy-e.html
+++ b/products/toy-e.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Luxury Toy | Toys Before Bed™</title>  <link href="../styles/styles.css" rel="stylesheet">
+  <title>Luxury Toy | Toys Before Bed™</title>
+  <link href="../styles/styles.css" rel="stylesheet">
 </head>
 <body id="top">
     <div id="navbar"></div>

--- a/products/toy-f.html
+++ b/products/toy-f.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Lube Gel | Toys Before Bed™</title>  <link href="../styles/styles.css" rel="stylesheet">
+  <title>Lube Gel | Toys Before Bed™</title>
+  <link href="../styles/styles.css" rel="stylesheet">
 </head>
 <body id="top">
     <div id="navbar"></div>


### PR DESCRIPTION
## Summary
- remove stray whitespace so stylesheet link is on its own line in blog and product pages
- normalize HTML line endings to LF for consistent validation

## Testing
- `npx htmlhint '**/*.html'` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_68c03e9621888326bc88ae58f399ee90