### PR TITLE
fix verifier workflows to run in bash

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -23,8 +23,7 @@ jobs:
           node-version: 22
 
       - name: Run verifier in auto-fix mode
-        run: |
-          node scripts/verify-includes.js || true
+        run: bash -c "node scripts/verify-includes.js || true"
 
       - name: Commit and push fixes
         run: |

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -20,9 +20,7 @@ jobs:
           node-version: 22
 
       - name: Run verifier
-        run: |
-          node scripts/verify-includes.js || true
-          echo "✅ HTML include and link verification complete"
+        run: bash -c "node scripts/verify-includes.js || true && echo '✅ HTML include and link verification complete'"
 
       - name: Upload reports
         if: always()
@@ -30,5 +28,6 @@ jobs:
         with:
           name: verify-reports
           path: |
-            verify-report.txt
+            verify-report*.txt
             broken-links.txt
+            *.log


### PR DESCRIPTION
## Summary
- ensure verify workflow runs node script via bash -c and uploads all reports
- run verifier in auto-fix workflow with bash -c

## Testing
- `node scripts/verify-includes.js || true` *(fails: Unexpected identifier 'and')*


------
https://chatgpt.com/codex/tasks/task_e_68c0bdc892cc83269f264b5f8660c0b5