### PR TITLE
Show test mode banner on non-production deployments

### DIFF
--- a/includes/navbar.html
+++ b/includes/navbar.html
@@ -4,6 +4,8 @@
 <!-- <link href="../styles/styles.css" rel="stylesheet"> -->
 
 <!-- includes/navbar.html -->
+<!-- Test mode banner (auto-controlled by JS) -->
+<div id="test-banner"></div>
 <nav class="navbar">
   <ul>
     <li><a href="/index.html">Home</a></li>

--- a/scripts/include.js
+++ b/scripts/include.js
@@ -67,3 +67,18 @@ document.addEventListener("DOMContentLoaded", () => {
     })
     .catch(err => console.error("Footer load error:", err));
 });
+
+// ------------------------------
+// Show test banner only on local/preview
+// ------------------------------
+document.addEventListener("DOMContentLoaded", () => {
+  const banner = document.getElementById("test-banner");
+  if (banner) {
+    const host = window.location.hostname;
+    // Show banner if not on production domain
+    if (host !== "toysbeforebed.com") {
+      banner.textContent = "⚠️ This site is in testing mode. Forms are disabled.";
+      banner.classList.add("active");
+    }
+  }
+});

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -261,3 +261,21 @@ footer .tagline {
   color: #ffd9a0;
 }
 
+/* ------------------------------
+   TEST MODE BANNER
+   Shown only on non-production (localhost / GitHub preview)
+------------------------------ */
+.test-banner {
+  display: none; /* hidden by default */
+  background: #ffeb99;   /* soft yellow */
+  color: #663300;        /* dark text */
+  text-align: center;
+  padding: 0.5rem;
+  font-size: 0.95rem;
+  font-weight: bold;
+  border-bottom: 2px solid #cc9900;
+}
+.test-banner.active {
+  display: block;
+}
+


### PR DESCRIPTION
## Summary
- Add test-mode banner placeholder to navbar include
- Style banner and default hidden state
- Display warning banner on non-production hosts via JS

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b1487648832682bdd3d33d3c58c8