### PR TITLE
Add test banner + Playwright screenshot verification (hidden in production, active in preview/local)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -34,3 +34,8 @@ jobs:
             verify-report*.txt
             broken-links.txt
             *.log
+      - name: Install Playwright
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright tests
+        run: npx playwright test --reporter=dot

--- a/tests/test-banner.spec.js
+++ b/tests/test-banner.spec.js
@@ -1,0 +1,15 @@
+const { test, expect } = require('@playwright/test');
+
+test('Test banner appears only on preview/local', async ({ page }) => {
+  // Localhost test
+  await page.goto('http://localhost:3000');
+  await expect(page.locator('#test-banner')).toHaveClass(/active/);
+
+  // GitHub Pages test (replace with your actual GH Pages URL if different)
+  await page.goto('https://mrobinson102.github.io/toysbeforebed/');
+  await expect(page.locator('#test-banner')).toHaveClass(/active/);
+
+  // Production domain test
+  await page.goto('https://toysbeforebed.com/');
+  await expect(page.locator('#test-banner')).not.toHaveClass(/active/);
+});


### PR DESCRIPTION
## Summary
- add Playwright tests to confirm banner visibility across local, preview and production environments
- run Playwright in CI workflow after installing dependencies

## Testing
- `npx playwright install --with-deps` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npx playwright test tests/test-banner.spec.js` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b273335483269296582b46a8a97f