### PR TITLE
Add breadcrumb placeholders to HTML pages

### DIFF
--- a/2257.html
+++ b/2257.html
@@ -11,10 +11,12 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
+    <div id="breadcrumbs"></div>
 <main class="page"><div class="container">
 <h2>18 U.S.C. §2257 Compliance Notice</h2><p>All models appearing on this website were 18+ at the time of photography. Records required by 18 U.S.C. §2257 are maintained by the custodian of records.</p></div></main>
 
     <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
+    <script src="scripts/breadcrumbs.js" defer></script>
   </body>
 </html>

--- a/about.html
+++ b/about.html
@@ -35,6 +35,7 @@
 
   <body id="top">
     <div id="navbar"></div>
+    <div id="breadcrumbs"></div>
     <main class="page">
     <div class="container">
       <h2>About Us</h2>
@@ -44,5 +45,6 @@
   </main>
     <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
+    <script src="scripts/breadcrumbs.js" defer></script>
   </body>
 </html>

--- a/bedside.html
+++ b/bedside.html
@@ -35,6 +35,7 @@
 
 <body id="top">
     <div id="navbar"></div>
+    <div id="breadcrumbs"></div>
   <main class="page">
     <div class="container">
       <h1>Bedside Reading</h1>
@@ -69,5 +70,6 @@
   </script>
     <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
+    <script src="scripts/breadcrumbs.js" defer></script>
   </body>
 </html>

--- a/bedside/guide-1.html
+++ b/bedside/guide-1.html
@@ -11,8 +11,10 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
+    <div id="breadcrumbs"></div>
 <div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>A Beginner’s Guide to Choosing Your First Vibrator</h1><p><em>Published: March 1, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for A Beginner’s Guide to Choosing Your First Vibrator.</p>
     <div id="footer"></div>
     <script src="../scripts/include.js" defer></script>
+    <script src="../scripts/breadcrumbs.js" defer></script>
   </body>
 </html>

--- a/bedside/guide-2.html
+++ b/bedside/guide-2.html
@@ -11,8 +11,10 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
+    <div id="breadcrumbs"></div>
 <div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>Understanding Discreet Shipping & Privacy</h1><p><em>Published: March 10, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for Understanding Discreet Shipping & Privacy.</p>
     <div id="footer"></div>
     <script src="../scripts/include.js" defer></script>
+    <script src="../scripts/breadcrumbs.js" defer></script>
   </body>
 </html>

--- a/bedside/guide-3.html
+++ b/bedside/guide-3.html
@@ -11,8 +11,10 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
+    <div id="breadcrumbs"></div>
 <div class='header'><img src="../assets/logo.png" alt='Toys Before Bed Logo'><strong>Toys Before Bed™</strong></div><h1>Couples’ Toys: How to Explore Together</h1><p><em>Published: March 20, 2025</em></p><img src="../assets/coming-soon.png" alt='Coming soon'><p>Placeholder content for Couples’ Toys: How to Explore Together.</p>
     <div id="footer"></div>
     <script src="../scripts/include.js" defer></script>
+    <script src="../scripts/breadcrumbs.js" defer></script>
   </body>
 </html>

--- a/blog.html
+++ b/blog.html
@@ -21,6 +21,7 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
+    <div id="breadcrumbs"></div>
 <main style="padding:40px;max-width:1200px;margin:auto;">
     <h1 style="text-align:center; color:#7c0e0c;">Bedside Reading</h1>
     <div class="grid">
@@ -54,5 +55,6 @@
 
       <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
+    <script src="scripts/breadcrumbs.js" defer></script>
   </body>
   </html>

--- a/blog/post-1.html
+++ b/blog/post-1.html
@@ -21,6 +21,7 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
+    <div id="breadcrumbs"></div>
 
 <main style="display:flex;max-width:1200px;margin:auto;padding:40px;gap:30px;flex-wrap:wrap;">
     <article style="flex:1 1 65%;min-width:280px;">
@@ -71,5 +72,6 @@
 
     <div id="footer"></div>
     <script src="../scripts/include.js" defer></script>
+    <script src="../scripts/breadcrumbs.js" defer></script>
   </body>
   </html>

--- a/blog/post-2.html
+++ b/blog/post-2.html
@@ -21,6 +21,7 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
+    <div id="breadcrumbs"></div>
 
 <main style="display:flex;max-width:1200px;margin:auto;padding:40px;gap:30px;flex-wrap:wrap;">
     <article style="flex:1 1 65%;min-width:280px;">
@@ -67,5 +68,6 @@
 
     <div id="footer"></div>
     <script src="../scripts/include.js" defer></script>
+    <script src="../scripts/breadcrumbs.js" defer></script>
   </body>
   </html>

--- a/blog/post-3.html
+++ b/blog/post-3.html
@@ -21,6 +21,7 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
+    <div id="breadcrumbs"></div>
 
 <main style="display:flex;max-width:1200px;margin:auto;padding:40px;gap:30px;flex-wrap:wrap;">
     <article style="flex:1 1 65%;min-width:280px;">
@@ -67,5 +68,6 @@
 
     <div id="footer"></div>
     <script src="../scripts/include.js" defer></script>
+    <script src="../scripts/breadcrumbs.js" defer></script>
   </body>
   </html>

--- a/contact.html
+++ b/contact.html
@@ -11,10 +11,12 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
+    <div id="breadcrumbs"></div>
 <main class="page"><div class="container">
 <h2>Contact Us</h2><p>We’ll reply within 1–2 business days.</p><form onsubmit="alert('Message sent! We’ll be in touch.');trackEvent('form_submit','contact');return false;"><input placeholder='Your Name' required><input type='email' placeholder='Email' required><textarea placeholder='Your message' required></textarea><button class='btn primary'>Send</button></form></div></main>
 
     <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
+    <script src="scripts/breadcrumbs.js" defer></script>
   </body>
 </html>

--- a/faq.html
+++ b/faq.html
@@ -11,10 +11,12 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
+    <div id="breadcrumbs"></div>
 <main class="page"><div class="container">
 <h2>FAQ</h2><details open><summary>Is shipping discreet?</summary><p>Yes — all orders ship in plain, unmarked packaging. 100% private.</p></details><details><summary>Do you offer free shipping?</summary><p>Yes — free shipping on orders over $50 (US) and £40+ (UK).</p></details><details><summary>Can I return items?</summary><p>Most items are final sale. Faulty products will be replaced or refunded.</p></details></div></main>
 
     <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
+    <script src="scripts/breadcrumbs.js" defer></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
 
     <body id="top">
       <div id="navbar"></div>
+      <div id="breadcrumbs"></div>
       <main>
       <section class="hero">
       <picture>
@@ -120,5 +121,6 @@
 
         <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
+    <script src="scripts/breadcrumbs.js" defer></script>
   </body>
 </html>

--- a/join.html
+++ b/join.html
@@ -26,6 +26,7 @@
 
 <body id="top">
     <div id="navbar"></div>
+    <div id="breadcrumbs"></div>
   <main class="page">
   <div class="container">
     <h2>Join Our Partner Program</h2>
@@ -51,5 +52,6 @@
 
       <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
+    <script src="scripts/breadcrumbs.js" defer></script>
   </body>
 </html>

--- a/privacy-uk.html
+++ b/privacy-uk.html
@@ -11,10 +11,12 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
+    <div id="breadcrumbs"></div>
 <main class="page"><div class="container">
 <h2>Privacy Policy (UK & EU GDPR)</h2><p>We comply with GDPR. You may request access, correction, or deletion of your data at any time.</p></div></main>
 
     <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
+    <script src="scripts/breadcrumbs.js" defer></script>
   </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -11,10 +11,12 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
+    <div id="breadcrumbs"></div>
 <main class="page"><div class="container">
 <h2>Privacy Policy (US)</h2><p>We respect your privacy. We collect minimal data to fulfill orders, provide customer support, and comply with US laws (CCPA, etc.). We never sell your data.</p></div></main>
 
     <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
+    <script src="scripts/breadcrumbs.js" defer></script>
   </body>
 </html>

--- a/products/toy-a.html
+++ b/products/toy-a.html
@@ -8,6 +8,7 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
+    <div id="breadcrumbs"></div>
 
 <main style="padding:40px;max-width:1000px;margin:auto;text-align:center;">
     <h1>Discreet Vibrator</h1>
@@ -20,5 +21,6 @@
 
       <div id="footer"></div>
     <script src="../scripts/include.js" defer></script>
+    <script src="../scripts/breadcrumbs.js" defer></script>
   </body>
 </html>

--- a/products/toy-b.html
+++ b/products/toy-b.html
@@ -8,6 +8,7 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
+    <div id="breadcrumbs"></div>
 
 <main style="padding:40px;max-width:1000px;margin:auto;text-align:center;">
     <h1>Couples’ Kit</h1>
@@ -20,5 +21,6 @@
 
       <div id="footer"></div>
     <script src="../scripts/include.js" defer></script>
+    <script src="../scripts/breadcrumbs.js" defer></script>
   </body>
 </html>

--- a/products/toy-c.html
+++ b/products/toy-c.html
@@ -8,6 +8,7 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
+    <div id="breadcrumbs"></div>
 
 <main style="padding:40px;max-width:1000px;margin:auto;text-align:center;">
     <h1>Massage Oil</h1>
@@ -20,5 +21,6 @@
 
       <div id="footer"></div>
     <script src="../scripts/include.js" defer></script>
+    <script src="../scripts/breadcrumbs.js" defer></script>
   </body>
 </html>

--- a/products/toy-d.html
+++ b/products/toy-d.html
@@ -8,6 +8,7 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
+    <div id="breadcrumbs"></div>
 
 <main style="padding:40px;max-width:1000px;margin:auto;text-align:center;">
     <h1>Wand Vibrator</h1>
@@ -20,5 +21,6 @@
 
       <div id="footer"></div>
     <script src="../scripts/include.js" defer></script>
+    <script src="../scripts/breadcrumbs.js" defer></script>
   </body>
 </html>

--- a/products/toy-e.html
+++ b/products/toy-e.html
@@ -8,6 +8,7 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
+    <div id="breadcrumbs"></div>
 
 <main style="padding:40px;max-width:1000px;margin:auto;text-align:center;">
     <h1>Luxury Toy</h1>
@@ -20,5 +21,6 @@
 
       <div id="footer"></div>
     <script src="../scripts/include.js" defer></script>
+    <script src="../scripts/breadcrumbs.js" defer></script>
   </body>
 </html>

--- a/products/toy-f.html
+++ b/products/toy-f.html
@@ -8,6 +8,7 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
+    <div id="breadcrumbs"></div>
 
 <main style="padding:40px;max-width:1000px;margin:auto;text-align:center;">
     <h1>Lube Gel</h1>
@@ -20,5 +21,6 @@
 
       <div id="footer"></div>
     <script src="../scripts/include.js" defer></script>
+    <script src="../scripts/breadcrumbs.js" defer></script>
   </body>
 </html>

--- a/returns.html
+++ b/returns.html
@@ -11,10 +11,12 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
+    <div id="breadcrumbs"></div>
 <main class="page"><div class="container">
 <h2>Returns Policy</h2><p>Due to the intimate nature of our products, most sales are final. Faulty products will be replaced or refunded.</p></div></main>
 
     <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
+    <script src="scripts/breadcrumbs.js" defer></script>
   </body>
 </html>

--- a/sitemap.html
+++ b/sitemap.html
@@ -8,6 +8,7 @@
 </head>
 <body id="top">
   <div id="navbar"></div>
+  <div id="breadcrumbs"></div>
   <main class="container">
     <h1>Sitemap</h1>
     <ul>
@@ -41,5 +42,6 @@
   </main>
   <div id="footer"></div>
   <script src="scripts/include.js" defer></script>
+  <script src="scripts/breadcrumbs.js" defer></script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -11,10 +11,12 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
+    <div id="breadcrumbs"></div>
 <main class="page"><div class="container">
 <h2>Terms of Use</h2><p>You must be 18+ to view or purchase. All content and products are © Toys Before Bed™. Do not redistribute without permission.</p></div></main>
 
     <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
+    <script src="scripts/breadcrumbs.js" defer></script>
   </body>
 </html>

--- a/thank-you.html
+++ b/thank-you.html
@@ -21,6 +21,7 @@
 </head>
 <body id="top">
     <div id="navbar"></div>
+    <div id="breadcrumbs"></div>
     <main class="page">
       <div class="container" style="padding:40px;max-width:800px;margin:auto;text-align:center;">
     <h1 style="color:#7c0e0c;">Thank You for Subscribing! 💌</h1>
@@ -31,5 +32,6 @@
 
     <div id="footer"></div>
     <script src="scripts/include.js" defer></script>
+    <script src="scripts/breadcrumbs.js" defer></script>
   </body>
   </html>


### PR DESCRIPTION
## Summary
- add a breadcrumbs container immediately after the navbar on every HTML page
- load the deferred breadcrumbs script before each closing body tag using the correct relative path

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c9a37073c08326813a49821b3b8097